### PR TITLE
feat: add on-device provider with scoped tool registration and multi-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ No form to fill. No start/stop buttons. No dashboard to check. No app-switching.
 io.github.brianmwas.koog_compose:koog-compose-core          ← DSL, agent runtime, phase engine   (required)
 io.github.brianmwas.koog_compose:koog-compose-ui            ← Material 3 Compose components       (optional)
 io.github.brianmwas.koog_compose:koog-compose-device        ← Android/iOS device tools            (optional)
+io.github.brianmwas.koog_compose:koog-compose-mediapipe     ← On-device ML models (LiteRT-LM, Apple FMs)  (optional)
 io.github.brianmwas.koog_compose:koog-compose-testing       ← Deterministic fake executor + test DSL
 io.github.brianmwas.koog_compose:koog-compose-session-room  ← Room-backed persistent memory       (optional)
 ```
@@ -223,10 +224,11 @@ io.github.brianmwas.koog_compose:koog-compose-session-room  ← Room-backed pers
 
 ```kotlin
 dependencies {
-    implementation("io.github.brianmwas.koog_compose:koog-compose-core:1.2.0")
-    implementation("io.github.brianmwas.koog_compose:koog-compose-ui:1.2.0")            // Compose UI components
-    implementation("io.github.brianmwas.koog_compose:koog-compose-device:1.2.0")        // Android/iOS device tools
-    implementation("io.github.brianmwas.koog_compose:koog-compose-session-room:1.2.0")  // Persistent memory via Room
+    implementation("io.github.brianmwas.koog_compose:koog-compose-core:1.3.0")
+    implementation("io.github.brianmwas.koog_compose:koog-compose-ui:1.3.0")            // Compose UI components
+    implementation("io.github.brianmwas.koog_compose:koog-compose-device:1.3.0")        // Android/iOS device tools
+    implementation("io.github.brianmwas.koog_compose:koog-compose-mediapipe:1.3.0")     // On-device ML models
+    implementation("io.github.brianmwas.koog_compose:koog-compose-session-room:1.3.0")  // Persistent memory via Room
 }
 ```
 
@@ -259,7 +261,18 @@ data class RunState(
 
 ```kotlin
 val fitnessAgent = koogCompose<RunState> {
-    provider { ollama(model = "llama3.2") } // on-device, no server needed
+    // Option 1: On-device model (Android: LiteRT-LM, iOS: Apple Foundation Models)
+    provider {
+        onDevice(modelPath = "/data/models/gemma-4-E2B.litertlm") {
+            maxToolRounds(8)
+            onUnavailable {
+                anthropic(apiKey = BuildConfig.KEY)
+            }
+        }
+    }
+
+    // Option 2: Cloud provider
+    provider { ollama(model = "llama3.2") }
 
     initialState { RunState(userName = "brian") }
 
@@ -676,6 +689,49 @@ val session = koogSession<Unit> {
 
 Handoff options: `description`, `continueHistory` (shared or fresh history), `onHandoff` callback.
 
+### Provider configuration
+
+koog-compose supports multiple AI providers through a unified DSL:
+
+```kotlin
+provider {
+    // On-device models (Android: LiteRT-LM, iOS: Apple Foundation Models)
+    onDevice(modelPath = "/data/models/gemma-4-E2B.litertlm") {
+        maxToolRounds(8)
+        onUnavailable { anthropic(apiKey = BuildConfig.KEY) }
+    }
+
+    // Cloud providers
+    anthropic(apiKey = BuildConfig.ANTHROPIC_KEY) { model = "claude-sonnet-4-20250514" }
+    openai(apiKey = BuildConfig.OPENAI_KEY) { model = "gpt-4o" }
+    ollama(model = "llama3.2") { baseUrl = "http://10.0.2.2:11434" }
+
+    // Router with fallback strategy
+    router(strategy = RouterStrategy.Fallback) {
+        provider { onDevice(modelPath = "...") }
+        provider { anthropic(apiKey = BuildConfig.KEY) }
+    }
+}
+```
+
+**On-device providers** run the model locally on the device. Tools still go through koog's SecureTool pipeline (validation + guardrails). Automatic tool calling is disabled so koog remains the orchestrator.
+
+| Platform | Implementation | Status |
+|---|---|---|
+| Android | LiteRT-LM with Gemma 4 (E2B/E4B .litertlm model) | ✅ Implemented |
+| iOS | Apple Foundation Models (iOS 26+) | ✅ Implemented |
+| Desktop | Stub (not implemented yet) | Planned |
+
+**Fallback configuration** — when the on-device model is unavailable (device not eligible, model not ready), koog-compose automatically falls back to the configured cloud provider:
+
+```kotlin
+onDevice(modelPath = "...") {
+    onUnavailable {
+        anthropic(apiKey = BuildConfig.KEY)
+    }
+}
+```
+
 ### Privacy & data ownership
 
 All data stays on the user's device by default. Nothing is transmitted externally unless you explicitly wire it up.
@@ -983,16 +1039,20 @@ The `:session-room` module includes a Room migration (`v1 → v2`) that adds the
 | Room session store | ✅ | ✅ | — |
 | Device tools (location) | ✅ | — | — |
 | WorkManager background | ✅ | — | — |
+| On-device provider (LiteRT-LM) | ✅ | — | — |
+| On-device provider (Apple FMs) | — | ✅ (iOS 26+) | — |
+| Provider fallback routing | ✅ | ✅ | ✅ |
 
 > **Note:** `koog-compose-core`, `koog-compose-ui`, and `koog-compose-session-room`
 > all compile for Android and iOS. `koog-compose-device` is Android-only
-> (WorkManager, Play Services Location). Desktop support for UI is planned.
+> (WorkManager, Play Services Location). `koog-compose-mediapipe` compiles for
+> Android, iOS, and Desktop — on-device providers are platform-specific.
 
 ---
 
 ## Roadmap
 
-### v1.2.0 (current)
+### v1.2.0
 - ✅ Structured outputs with validation & self-correction
 - ✅ Schema versioning for evolving output types
 - ✅ Tool call frequency tracking per session
@@ -1014,11 +1074,34 @@ The `:session-room` module includes a Room migration (`v1 → v2`) that adds the
 - ✅ Lenient deserialization by default (`ignoreUnknownKeys` + `coerceInputValues`)
 - ✅ Room database auto-migration (v1 → v2) for `serializedStateVersion` column
 
-### v1.3.0
-- **ActivityResult integration** — camera, file picker, permissions as agent tools
-- **Structured observability** — pluggable `EventSink` for Firebase, Datadog, custom backends
-- **Custom PersistenceStorageProvider** — SQLite, Keychain, cloud sync
-- **Desktop Compose UI** — JVM support for `koog-compose-ui`
+### v1.3.0 (current)
+- ✅ Structured outputs with validation & self-correction
+- ✅ Schema versioning for evolving output types
+- ✅ Tool call frequency tracking per session
+- ✅ Multi-agent handoff via `handoff(agentRef)`
+- ✅ `[ToolName]` reference resolution in phase instructions
+- ✅ Subphases — sequential steps inside a single phase
+- ✅ Parallel branches — concurrent tool execution via `nodeExecuteMultipleTools(parallelTools = true)`
+- ✅ `resumeAt()` — jump to any phase from external triggers
+- ✅ Reusable templates — `phaseTemplate` and `subphaseTemplate` with `include()`
+- ✅ Nesting guardrails — clear errors for accidental deep nesting
+- ✅ Rich JSON Schema tool parameter types (String, Integer, Boolean, Enum, Array, Object)
+- ✅ Privacy & data ownership — all data stays on device by default
+- ✅ Audit log args redaction for PII-sensitive apps
+- ✅ Agent checkpoints (opt-in via `Persistence` feature)
+- ✅ Background task tools via WorkManager (Android)
+- ✅ RoomSessionStore persists `serializedState` and `toolCallCounts`
+- ✅ `KoogRoutine` registers phase tools and transitions
+- ✅ Schema migration utilities — `StateMigration` interface for evolving app state
+- ✅ Lenient deserialization by default (`ignoreUnknownKeys` + `coerceInputValues`)
+- ✅ Room database auto-migration (v1 → v2) for `serializedStateVersion` column
+- ✅ **On-device provider** — `onDevice { }` DSL with fallback routing
+- ✅ **LiteRT-LM integration** — Gemma 4 (E2B/E4B) on Android via MediaPipe
+- ✅ **Apple Foundation Models** — on-device inference on iOS 26+
+- ✅ **Scoped tool registration** — phase-local and transition tools scoped to subgraphs, not global
+- ✅ **Deduplicated tool resolution** — `resolveEffectiveTools()` prevents conflicts by name
+- ✅ **ProviderRuntimeRegistry** — pluggable AIProvider factory for platform modules
+- ✅ **Multi-platform MediaPipe module** — Android, iOS, Desktop targets
 
 ### v1.4.0
 - **Screenshot context tool** — give the agent a view of the current screen

--- a/iosApp/iosApp/AppleFoundationModelsBridge.swift
+++ b/iosApp/iosApp/AppleFoundationModelsBridge.swift
@@ -1,0 +1,101 @@
+import FoundationModels
+import ComposeApp
+
+@available(iOS 26.0, *)
+final class AppleFoundationModelsBridgeImpl: NSObject, AppleFoundationModelsBridge {
+    func isAvailable() -> Bool {
+        SystemLanguageModel.default.isAvailable
+    }
+
+    func unavailableReason() -> String? {
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return nil
+        case .unavailable(let reason):
+            switch reason {
+            case .deviceNotEligible:
+                return "This device is not eligible for Apple Intelligence."
+            case .appleIntelligenceNotEnabled:
+                return "Apple Intelligence is not enabled."
+            case .modelNotReady:
+                return "The on-device model is not ready yet."
+            @unknown default:
+                return "The on-device model is unavailable."
+            }
+        @unknown default:
+            return "The on-device model is unavailable."
+        }
+    }
+
+    func supportsToolCalls() -> Bool {
+        false
+    }
+
+    func execute(
+        systemPrompt: String?,
+        userPrompt: String,
+        onComplete: @escaping (String?, String?) -> Void
+    ) {
+        Task {
+            do {
+                let session = makeSession(systemPrompt: systemPrompt)
+                let response = try await session.respond(to: userPrompt)
+                onComplete(response.content, nil)
+            } catch {
+                onComplete(nil, String(describing: error))
+            }
+        }
+    }
+
+    func stream(
+        systemPrompt: String?,
+        userPrompt: String,
+        onToken: @escaping (String) -> Void,
+        onComplete: @escaping (String?) -> Void
+    ) {
+        Task {
+            do {
+                let session = makeSession(systemPrompt: systemPrompt)
+                var emitted = ""
+
+                for try await snapshot in session.streamResponse(to: userPrompt) {
+                    let full = String(describing: snapshot.content)
+                    let nextChunk: String
+
+                    if full.hasPrefix(emitted) {
+                        nextChunk = String(full.dropFirst(emitted.count))
+                    } else {
+                        nextChunk = full
+                    }
+
+                    if !nextChunk.isEmpty {
+                        onToken(nextChunk)
+                    }
+                    emitted = full
+                }
+
+                onComplete(nil)
+            } catch {
+                onComplete(String(describing: error))
+            }
+        }
+    }
+
+    private func makeSession(systemPrompt: String?) -> LanguageModelSession {
+        if let systemPrompt, !systemPrompt.isEmpty {
+            return LanguageModelSession(instructions: systemPrompt)
+        } else {
+            return LanguageModelSession()
+        }
+    }
+}
+
+func installAppleFoundationModelsBridgeIfAvailable() {
+    OnDeviceAIProviderKt.installOnDeviceProviderSupport()
+
+    if #available(iOS 26.0, *) {
+        AppleFoundationModelsBridgeSupportKt.installAppleFoundationModelsBridge(
+            bridge: AppleFoundationModelsBridgeImpl()
+        )
+    }
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 @main
 struct iOSApp: App {
+    init() {
+        installAppleFoundationModelsBridgeIfAvailable()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/phase/PhaseAwareAgent.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/phase/PhaseAwareAgent.kt
@@ -85,33 +85,12 @@ public object PhaseAwareAgent {
         val llmModel = provider.resolveModelForConfig()
         val strategy = PhaseStrategyBuilder.build(resolvedContext, strategyName)
 
-        // Agent-level registry: all tools from all phases (including subphases
-        // and parallel branches) + transitions.
+        // Agent-level registry: only session-global tools live here.
+        // Phase-local and transition tools are scoped on the subgraphs built
+        // by PhaseStrategyBuilder, which keeps the model's visible tool set
+        // smaller for each active phase.
         val globalKoogRegistry = KoogToolRegistry {
             resolvedContext.toolRegistry.all.forEach { tool(it.toKoogTool()) }
-            resolvedContext.phaseRegistry.all.forEach { phase ->
-                // Parent phase tools
-                phase.toolRegistry.all.forEach { tool(it.toKoogTool()) }
-                phase.transitions.forEach { transition ->
-                    tool(transition.toTool().toKoogTool())
-                }
-                // Subphase tools + transitions
-                phase.subphases.forEach { sub ->
-                    sub.toolRegistry.all.forEach { tool(it.toKoogTool()) }
-                    sub.transitions.forEach { transition ->
-                        tool(transition.toTool().toKoogTool())
-                    }
-                }
-                // Parallel branch tools + transitions
-                phase.parallelGroups.forEach { group ->
-                    group.forEach { branch ->
-                        branch.toolRegistry.all.forEach { tool(it.toKoogTool()) }
-                        branch.transitions.forEach { transition ->
-                            tool(transition.toTool().toKoogTool())
-                        }
-                    }
-                }
-            }
         }
 
         val initialPhase = resolvedContext.phaseRegistry.initialPhase

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/phase/Routine.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/phase/Routine.kt
@@ -76,17 +76,10 @@ public class KoogRoutine(
             serializer = KotlinxSerializer()
         )
 
-        // Register ALL tools — global + all phases + all transitions.
-        // This matches PhaseAwareAgent's approach so the LLM has full tool
-        // visibility regardless of which phase it's currently in.
+        // Only session-global tools live on the agent-level registry.
+        // Phase-local and transition tools are scoped on the graph subgraphs.
         val toolRegistry = KoogToolRegistry {
             context.toolRegistry.all.forEach { tool(it.toKoogTool()) }
-            context.phaseRegistry.all.forEach { phase ->
-                phase.toolRegistry.all.forEach { tool(it.toKoogTool()) }
-                phase.transitions.forEach { transition ->
-                    tool(transition.toTool().toKoogTool())
-                }
-            }
         }
 
         return AIAgent(

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/provider/KoogaiProvider.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/provider/KoogaiProvider.kt
@@ -218,6 +218,12 @@ internal fun buildClientForProvider(config: ProviderConfig): LLMClient = when (c
         "koog-compose: LiteRT-LM requires :koog-compose-mediapipe module. " +
             "Use LiteRtLmProvider directly instead of KoogAIProvider."
     )
+    is ProviderConfig.OnDevice -> error(
+        "koog-compose: OnDevice provider requires :koog-compose-mediapipe module. " +
+            "The on-device model runs through OnDeviceProvider, not the standard " +
+            "KoogAIProvider. Use koogCompose { provider { onDevice(...) } } and the " +
+            "framework will route through OnDeviceProvider automatically."
+    )
     is ProviderConfig.Router -> error("Nested routers are not supported")
 }
 
@@ -251,6 +257,15 @@ internal fun resolveModel(config: ProviderConfig): LLModel = when (config) {
     is ProviderConfig.LiteRtLm -> LLModel(
         provider = LLMProvider.Ollama, // reuse Ollama provider type as placeholder
         id = "litertlm-gemma3",
+        capabilities = listOf(
+            LLMCapability.Completion,
+            LLMCapability.Tools,
+        )
+    )
+
+    is ProviderConfig.OnDevice -> LLModel(
+        provider = LLMProvider.Ollama,
+        id = "on-device-gemma4",
         capabilities = listOf(
             LLMCapability.Completion,
             LLMCapability.Tools,
@@ -374,6 +389,7 @@ private fun ProviderConfig.defaultTemperature(): Double? = when (this) {
     is ProviderConfig.Ollama -> temperature
     is ProviderConfig.OpenAI -> temperature
     is ProviderConfig.LiteRtLm -> null
+    is ProviderConfig.OnDevice -> null
     is ProviderConfig.Router -> providers.firstOrNull()?.defaultTemperature()
 }
 
@@ -383,6 +399,7 @@ private fun ProviderConfig.defaultMaxTokens(): Int? = when (this) {
     is ProviderConfig.Ollama -> maxTokens
     is ProviderConfig.OpenAI -> maxTokens
     is ProviderConfig.LiteRtLm -> maxTokens
+    is ProviderConfig.OnDevice -> null
     is ProviderConfig.Router -> providers.firstOrNull()?.defaultMaxTokens()
 }
 

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/provider/ProviderConfig.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/provider/ProviderConfig.kt
@@ -106,6 +106,29 @@ public sealed class ProviderConfig {
         val providers: List<ProviderConfig>,
         val strategy: RouterStrategy = RouterStrategy.RoundRobin,
     ) : ProviderConfig()
+
+    /**
+     * On-device provider — runs the model locally on the device.
+     *
+     * Android: LiteRT-LM with Gemma 4 (E2B/E4B .litertlm model).
+     * iOS: planned Apple Foundation Models integration. Not implemented yet.
+     *
+     * Tools go through koog's SecureTool pipeline (validation + guardrails).
+     * Automatic tool calling is disabled so koog remains the orchestrator.
+     *
+     * ```kotlin
+     * provider {
+     *     onDevice(modelPath = "/data/models/gemma-4-E2B.litertlm") {
+     *         onUnavailable { anthropic(apiKey = BuildConfig.KEY) }
+     *     }
+     * }
+     * ```
+     */
+    public data class OnDevice(
+        val modelPath: String = "",
+        val maxToolRounds: Int = 5,
+        val fallback: ProviderConfig? = null,
+    ) : ProviderConfig()
 }
 
 public enum class RouterStrategy { RoundRobin, Fallback }
@@ -150,6 +173,36 @@ public class ProviderConfigBuilder {
         block: LiteRtLmBuilder.() -> Unit = {}
     ) {
         config = LiteRtLmBuilder(modelPath).apply(block).build()
+    }
+
+    /**
+     * Configures an on-device provider.
+     *
+     * Simple usage:
+     * ```kotlin
+     * provider {
+     *     onDevice(modelPath = "/data/models/gemma-4-E2B.litertlm")
+     * }
+     * ```
+     *
+     * With tools and fallback:
+     * ```kotlin
+     * provider {
+     *     onDevice(modelPath = "/data/models/gemma-4-E4B.litertlm") {
+     *         maxToolRounds(8)
+     *         onUnavailable {
+     *             anthropic(apiKey = BuildConfig.KEY)
+     *         }
+     *     }
+     * }
+     * ```
+     */
+    public fun onDevice(
+        modelPath: String = "",
+        block: OnDeviceProviderBuilder.() -> Unit = {},
+    ) {
+        val builder = OnDeviceProviderBuilder(modelPath).apply(block)
+        config = builder.build()
     }
 
     public fun router(
@@ -225,4 +278,41 @@ public class RouterBuilder(private val strategy: RouterStrategy) {
     }
 
     public fun build(): ProviderConfig = ProviderConfig.Router(providers.toList(), strategy)
+}
+
+/**
+ * Builder for [ProviderConfig.OnDevice] inside the provider DSL.
+ */
+public class OnDeviceProviderBuilder internal constructor(
+    private val modelPath: String,
+) {
+    private var maxToolRounds: Int = 5
+    internal var unavailableHandler: (() -> ProviderConfig)? = null
+
+    /** Maximum agentic loop iterations before capping and returning. */
+    public fun maxToolRounds(max: Int) {
+        require(max > 0) { "maxToolRounds must be > 0" }
+        this.maxToolRounds = max
+    }
+
+    /**
+     * Provides a fallback provider when the on-device model is unavailable.
+     *
+     * ```kotlin
+     * onUnavailable { anthropic(apiKey = BuildConfig.KEY) }
+     * // or
+     * onUnavailable { ollama(model = "llama3.2") }
+     * ```
+     */
+    public fun onUnavailable(fallback: ProviderConfigBuilder.() -> Unit) {
+        this.unavailableHandler = { ProviderConfigBuilder().apply(fallback).build() }
+    }
+
+    internal fun build(): ProviderConfig {
+        return ProviderConfig.OnDevice(
+            modelPath = modelPath,
+            maxToolRounds = maxToolRounds,
+            fallback = unavailableHandler?.invoke(),
+        )
+    }
 }

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/provider/ProviderRuntimeRegistry.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/provider/ProviderRuntimeRegistry.kt
@@ -1,0 +1,21 @@
+package io.github.koogcompose.provider
+
+import io.github.koogcompose.session.KoogComposeContext
+
+/**
+ * Optional runtime hook for platform/provider modules that need to supply a
+ * custom [AIProvider] for specific [ProviderConfig] values.
+ *
+ * Core falls back to [KoogAIProvider] when no registered factory claims the
+ * context.
+ */
+public object ProviderRuntimeRegistry {
+    private val factories = mutableListOf<(KoogComposeContext<*>) -> AIProvider?>()
+
+    public fun register(factory: (KoogComposeContext<*>) -> AIProvider?) {
+        factories += factory
+    }
+
+    internal fun create(context: KoogComposeContext<*>): AIProvider? =
+        factories.asReversed().firstNotNullOfOrNull { it(context) }
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/KoogComposeContext.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/KoogComposeContext.kt
@@ -7,6 +7,7 @@ import io.github.koogcompose.phase.toTool
 import io.github.koogcompose.prompt.PromptStack
 import io.github.koogcompose.provider.AIProvider
 import io.github.koogcompose.provider.KoogAIProvider
+import io.github.koogcompose.provider.ProviderRuntimeRegistry
 import io.github.koogcompose.provider.ProviderConfig
 import io.github.koogcompose.provider.ProviderConfigBuilder
 import io.github.koogcompose.security.Guardrails
@@ -284,7 +285,8 @@ public data class KoogComposeContext<S>(
     val config: KoogConfig,
     val contextualInstructions: List<ContextualInstruction> = emptyList(),
 ) : KoogDefinition<S> {
-    public fun createProvider(): AIProvider = KoogAIProvider(this)
+    public fun createProvider(): AIProvider =
+        ProviderRuntimeRegistry.create(this) ?: KoogAIProvider(this)
     public val provider: AIProvider get() = createProvider()
 
     /**
@@ -349,9 +351,14 @@ public data class KoogComposeContext<S>(
 
     public fun resolveEffectiveTools(): List<SecureTool> {
         val phase = activePhase ?: phaseRegistry.initialPhase
-        val baseTools = phase?.toolRegistry?.all ?: toolRegistry.all
+        val baseTools = buildList {
+            addAll(toolRegistry.all)
+            if (phase != null) {
+                addAll(phase.toolRegistry.all)
+            }
+        }
         val transitionTools = phase?.transitions?.map { it.toTool() } ?: emptyList()
-        return baseTools + transitionTools
+        return (baseTools + transitionTools).distinctBy(SecureTool::name)
     }
 
     public class Builder<S> {

--- a/koog-compose-mediapipe/build.gradle.kts
+++ b/koog-compose-mediapipe/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.dokka)
     id("publish-convention")
@@ -15,12 +16,22 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_11)
         }
     }
+    jvm("desktop") {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
-        androidMain.dependencies {
+        commonMain.dependencies {
             api(project(":koog-compose-core"))
-            implementation(libs.litertlm.android)
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.serialization.json)
+        }
+        androidMain.dependencies {
+            implementation(libs.litertlm.android)
         }
     }
 }

--- a/koog-compose-mediapipe/src/androidMain/kotlin/io/github/koogcompose/provider/ondevice/LiteRtLmToolOrchestrator.kt
+++ b/koog-compose-mediapipe/src/androidMain/kotlin/io/github/koogcompose/provider/ondevice/LiteRtLmToolOrchestrator.kt
@@ -1,0 +1,111 @@
+package io.github.koogcompose.provider.ondevice.android
+
+import com.google.ai.edge.litertlm.Conversation
+import io.github.koogcompose.provider.ondevice.android.LiteRtLmToolOrchestrator.ToolCallRequest
+import io.github.koogcompose.tool.SecureTool
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Owns the agentic loop between a LiteRT-LM Conversation and koog-compose's
+ * SecureTool pipeline.
+ *
+ * Why this exists: LiteRT-LM automatic tool calling bypasses koog validation,
+ * guardrails, and event emission. By setting automaticToolCalling to false
+ * and using this orchestrator, we keep koog as the single authoritative
+ * dispatcher.
+ *
+ * Gemma 4 tool call format uses open/close tool call tag delimiters. Tool
+ * results are fed back as a user turn containing a JSON result object.
+ *
+ * Loop contract each round:
+ *   1. Collect a full response from the model.
+ *   2. If a tool call tag is found, dispatch and inject result, repeat.
+ *   3. If no tool call, return the response as the final answer.
+ *   4. If maxRounds is reached, return the last partial response with a
+ *      warning prefix so callers are aware the loop was capped.
+ */
+internal class LiteRtLmToolOrchestrator(
+    private val conversation: Conversation,
+    private val toolRegistry: Map<String, SecureTool>,
+    private val maxRounds: Int = 5,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val toolCallRegex = Regex(
+        """<function_call>(.*?)</function_call>""",
+        setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE)
+    )
+
+    suspend fun runLoop(initialUserMessage: String): String {
+        var fullResponse = collectFullResponse(initialUserMessage)
+        var round = 0
+
+        while (round < maxRounds) {
+            val toolCallMatch = toolCallRegex.find(fullResponse)
+                ?: break
+
+            val toolCallJson = toolCallMatch.groupValues[1].trim()
+            val toolCallRequest = parseToolCall(toolCallJson)
+                ?: break
+
+            val toolResult = dispatchTool(toolCallRequest)
+            fullResponse = collectFullResponse(formatToolResponse(toolResult))
+            round++
+        }
+
+        if (round == maxRounds) {
+            return LOOP_CAP_PREFIX + fullResponse
+        }
+
+        return fullResponse
+    }
+
+    internal suspend fun collectFullResponse(userMessage: String): String {
+        val sb = StringBuilder()
+        conversation.sendMessageAsync(userMessage).collect { message ->
+            sb.append(message.toString())
+        }
+        return sb.toString()
+    }
+
+    internal data class ToolCallRequest(
+        val name: String,
+        val arguments: JsonObject = JsonObject(emptyMap()),
+    )
+
+    private fun parseToolCall(rawJson: String): ToolCallRequest? =
+        try {
+            json.decodeFromString<ToolCallRequest>(rawJson)
+        } catch (e: Exception) {
+            null
+        }
+
+    private suspend fun dispatchTool(request: ToolCallRequest): String {
+        val tool = toolRegistry[request.name]
+            ?: return errorResult("Tool '${request.name}' is not registered.")
+
+        return try {
+            val result = tool.execute(request.arguments)
+            val output = when (result) {
+                is io.github.koogcompose.tool.ToolResult.Success -> result.output
+                is io.github.koogcompose.tool.ToolResult.Failure -> result.message
+                is io.github.koogcompose.tool.ToolResult.Denied -> result.reason
+                is io.github.koogcompose.tool.ToolResult.Structured<*> -> result.toJson()
+            }
+            json.encodeToString(mapOf("result" to output))
+        } catch (e: Exception) {
+            errorResult("Tool execution failed: ${e.message}")
+        }
+    }
+
+    private fun formatToolResponse(result: String): String =
+        "User: <tool_result>$result</tool_result>"
+
+    private fun errorResult(message: String): String =
+        json.encodeToString(mapOf("error" to message))
+
+    companion object {
+        const val LOOP_CAP_PREFIX = "[koog:loop_cap] "
+    }
+}

--- a/koog-compose-mediapipe/src/androidMain/kotlin/io/github/koogcompose/provider/ondevice/OnDeviceProvider.android.kt
+++ b/koog-compose-mediapipe/src/androidMain/kotlin/io/github/koogcompose/provider/ondevice/OnDeviceProvider.android.kt
@@ -1,0 +1,210 @@
+package io.github.koogcompose.provider.ondevice
+
+import com.google.ai.edge.litertlm.ConversationConfig
+import com.google.ai.edge.litertlm.Contents
+import com.google.ai.edge.litertlm.Engine
+import com.google.ai.edge.litertlm.EngineConfig
+import com.google.ai.edge.litertlm.LogSeverity
+import io.github.koogcompose.provider.ondevice.android.LiteRtLmToolOrchestrator.ToolCallRequest
+import io.github.koogcompose.provider.ondevice.android.LiteRtLmToolOrchestrator
+import io.github.koogcompose.tool.SecureTool
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import java.io.File
+
+/**
+ * Android actual for OnDeviceProvider.
+ *
+ * Backed by LiteRT-LM and Gemma 4 (E2B or E4B .litertlm models).
+ *
+ * Tool calling design: automaticToolCalling is set to false. Tool dispatch
+ * is handled by LiteRtLmToolOrchestrator which parses Gemma 4 tool call
+ * format, routes through koog SecureTool pipeline (validation + guardrails),
+ * and feeds results back into the conversation.
+ */
+public actual class OnDeviceProvider public actual constructor(
+    private val modelPath: String,
+    private val tools: List<SecureTool>,
+    private val maxToolRounds: Int,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val toolRegistry: Map<String, SecureTool> =
+        tools.associateBy { it.name }
+
+    private val engine: Engine by lazy {
+        Engine.setNativeMinLogSeverity(LogSeverity.ERROR)
+        val config = EngineConfig(modelPath = modelPath)
+        Engine(config).also { it.initialize() }
+    }
+
+    public actual fun isAvailable(): Boolean =
+        try {
+            File(modelPath).exists().also { exists ->
+                if (exists) engine
+            }
+        } catch (e: Exception) {
+            false
+        }
+
+    public actual fun supportsToolCalls(): Boolean = true
+
+    public actual suspend fun execute(prompt: OnDevicePrompt): String =
+        withContext(Dispatchers.IO) {
+            engine.createConversation(buildConversationConfig(prompt)).use { conversation ->
+                val orchestrator = LiteRtLmToolOrchestrator(
+                    conversation = conversation,
+                    toolRegistry = toolRegistry,
+                    maxRounds = maxToolRounds,
+                )
+                orchestrator.runLoop(prompt.user)
+            }
+        }
+
+    public actual fun executeStreaming(prompt: OnDevicePrompt): Flow<String> = callbackFlow {
+        val conversation = engine.createConversation(buildConversationConfig(prompt))
+
+        try {
+            var currentMessage = prompt.user
+            var round = 0
+
+            while (round < maxToolRounds) {
+                val parser = StreamingToolCallParser(
+                    onText = { chunk -> trySend(chunk) }
+                )
+
+                val request = try {
+                    conversation.sendMessageAsync(currentMessage).collect { message ->
+                        val completedRequest = parser.consume(message.toString())
+                        if (completedRequest != null) {
+                            throw StreamingToolCallCaptured(completedRequest)
+                        }
+                    }
+                    parser.flush()
+                    null
+                } catch (captured: StreamingToolCallCaptured) {
+                    captured.request
+                }
+
+                if (request == null) {
+                    break
+                }
+
+                val result = dispatchToolForStream(request)
+                currentMessage = "User: <tool_result>$result</tool_result>"
+                round++
+            }
+        } finally {
+            conversation.close()
+            close()
+        }
+
+        awaitClose { conversation.close() }
+    }
+
+    public actual fun close() {
+        runCatching { engine.close() }
+    }
+
+    private fun buildConversationConfig(prompt: OnDevicePrompt): ConversationConfig {
+        return ConversationConfig(
+            systemInstruction = prompt.system?.let { Contents.of(it) },
+            automaticToolCalling = false,
+        )
+    }
+
+    private fun parseToolCallForStream(rawJson: String): ToolCallRequest? =
+        try {
+            json.decodeFromString<ToolCallRequest>(rawJson)
+        } catch (e: Exception) {
+            null
+        }
+
+    private suspend fun dispatchToolForStream(request: ToolCallRequest): String {
+        val tool = toolRegistry[request.name]
+            ?: return json.encodeToString(mapOf("error" to "Tool '${request.name}' not registered"))
+        return try {
+            val result = tool.execute(request.arguments)
+            val output = when (result) {
+                is io.github.koogcompose.tool.ToolResult.Success -> result.output
+                is io.github.koogcompose.tool.ToolResult.Failure -> result.message
+                is io.github.koogcompose.tool.ToolResult.Denied -> result.reason
+                is io.github.koogcompose.tool.ToolResult.Structured<*> -> result.toJson()
+            }
+            json.encodeToString(mapOf("result" to output))
+        } catch (e: Exception) {
+            json.encodeToString(mapOf("error" to (e.message ?: "Unknown error")))
+        }
+    }
+
+    private inner class StreamingToolCallParser(
+        private val onText: (String) -> Unit,
+    ) {
+        private val startTag = "<function_call>"
+        private val endTag = "</function_call>"
+        private val carry = StringBuilder()
+        private val toolJson = StringBuilder()
+        private var inToolCall = false
+
+        fun consume(chunk: String): ToolCallRequest? {
+            carry.append(chunk)
+
+            while (true) {
+                if (!inToolCall) {
+                    val startIndex = carry.indexOf(startTag)
+                    if (startIndex >= 0) {
+                        emitText(carry.substring(0, startIndex))
+                        carry.delete(0, startIndex + startTag.length)
+                        inToolCall = true
+                        continue
+                    }
+
+                    val safeTextLength = carry.length - (startTag.length - 1)
+                    if (safeTextLength > 0) {
+                        emitText(carry.substring(0, safeTextLength))
+                        carry.delete(0, safeTextLength)
+                    }
+                    return null
+                }
+
+                val endIndex = carry.indexOf(endTag)
+                if (endIndex >= 0) {
+                    toolJson.append(carry.substring(0, endIndex))
+                    carry.delete(0, endIndex + endTag.length)
+                    val rawJson = toolJson.toString().trim()
+                    toolJson.clear()
+                    inToolCall = false
+                    return parseToolCallForStream(rawJson)
+                }
+
+                val safeToolLength = carry.length - (endTag.length - 1)
+                if (safeToolLength > 0) {
+                    toolJson.append(carry.substring(0, safeToolLength))
+                    carry.delete(0, safeToolLength)
+                }
+                return null
+            }
+        }
+
+        fun flush() {
+            if (!inToolCall && carry.isNotEmpty()) {
+                emitText(carry.toString())
+                carry.clear()
+            }
+        }
+
+        private fun emitText(text: String) {
+            if (text.isEmpty()) return
+            text.chunked(32).forEach(onText)
+        }
+    }
+
+    private class StreamingToolCallCaptured(
+        val request: ToolCallRequest,
+    ) : RuntimeException()
+}

--- a/koog-compose-mediapipe/src/androidMain/kotlin/io/github/koogcompose/provider/ondevice/SecureToolOpenApiAdapter.kt
+++ b/koog-compose-mediapipe/src/androidMain/kotlin/io/github/koogcompose/provider/ondevice/SecureToolOpenApiAdapter.kt
@@ -1,0 +1,65 @@
+package io.github.koogcompose.provider.ondevice.android
+
+import com.google.ai.edge.litertlm.OpenApiTool
+import io.github.koogcompose.tool.ParameterDescriptor
+import io.github.koogcompose.tool.SecureTool
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Adapts a koog-compose SecureTool into a LiteRT-LM OpenApiTool.
+ *
+ * LiteRT-LM uses the OpenAPI JSON schema to build the tool description
+ * injected into the model's system prompt and drive constrained decoding.
+ *
+ * We supply the schema here but do NOT implement execute for actual dispatch —
+ * automaticToolCalling is set to false, so LiteRT-LM never calls execute.
+ * All dispatch goes through koog's SecureTool pipeline in LiteRtLmToolOrchestrator.
+ */
+internal class SecureToolOpenApiAdapter(
+    private val secureTool: SecureTool,
+) : OpenApiTool {
+
+    override fun getToolDescriptionJsonString(): String {
+        val parameters = JSONObject().apply {
+            put("type", "object")
+            put("properties", buildProperties())
+            put("required", buildRequired())
+        }
+
+        return JSONObject().apply {
+            put("name", secureTool.name)
+            put("description", secureTool.description)
+            put("parameters", parameters)
+        }.toString()
+    }
+
+    override fun execute(paramsJsonString: String): String {
+        error(
+            "SecureToolOpenApiAdapter.execute() should never be called directly. " +
+                "automaticToolCalling must be false when using koog-compose."
+        )
+    }
+
+    private fun buildProperties(): JSONObject {
+        val props = JSONObject()
+        secureTool.describeParameters().forEach { param ->
+            props.put(param.name, paramToJsonSchema(param))
+        }
+        return props
+    }
+
+    private fun buildRequired(): JSONArray {
+        val required = JSONArray()
+        secureTool.describeParameters()
+            .filter { it.required }
+            .forEach { required.put(it.name) }
+        return required
+    }
+
+    private fun paramToJsonSchema(param: ParameterDescriptor): JSONObject =
+        JSONObject().apply {
+            put("type", param.type)
+            put("description", param.description)
+        }
+}

--- a/koog-compose-mediapipe/src/commonMain/kotlin/io/github/koogcompose/provider/ondevice/AppleFoundationModelsBridgeSupport.kt
+++ b/koog-compose-mediapipe/src/commonMain/kotlin/io/github/koogcompose/provider/ondevice/AppleFoundationModelsBridgeSupport.kt
@@ -1,0 +1,43 @@
+package io.github.koogcompose.provider.ondevice
+
+/**
+ * ObjC/Swift-friendly bridge contract for Apple Foundation Models.
+ *
+ * The implementation lives on the Swift side because the system framework is
+ * Apple-platform-native and evolves independently of Kotlin/Native exports.
+ */
+public interface AppleFoundationModelsBridge {
+    public fun isAvailable(): Boolean
+    public fun unavailableReason(): String?
+    public fun supportsToolCalls(): Boolean
+    public fun execute(
+        systemPrompt: String?,
+        userPrompt: String,
+        onComplete: (result: String?, error: String?) -> Unit,
+    )
+    public fun stream(
+        systemPrompt: String?,
+        userPrompt: String,
+        onToken: (String) -> Unit,
+        onComplete: (error: String?) -> Unit,
+    )
+}
+
+public object AppleFoundationModelsBridgeRegistry {
+    public var bridge: AppleFoundationModelsBridge? = null
+}
+
+public fun installAppleFoundationModelsBridge(bridge: AppleFoundationModelsBridge) {
+    AppleFoundationModelsBridgeRegistry.bridge = bridge
+}
+
+public fun clearAppleFoundationModelsBridge() {
+    AppleFoundationModelsBridgeRegistry.bridge = null
+}
+
+public fun installOnDeviceBridges(bridge: AppleFoundationModelsBridge? = null) {
+    installOnDeviceProviderSupport()
+    if (bridge != null) {
+        installAppleFoundationModelsBridge(bridge)
+    }
+}

--- a/koog-compose-mediapipe/src/commonMain/kotlin/io/github/koogcompose/provider/ondevice/OnDeviceAIProvider.kt
+++ b/koog-compose-mediapipe/src/commonMain/kotlin/io/github/koogcompose/provider/ondevice/OnDeviceAIProvider.kt
@@ -1,0 +1,147 @@
+package io.github.koogcompose.provider.ondevice
+
+import io.github.koogcompose.provider.AIProvider
+import io.github.koogcompose.provider.ProviderConfig
+import io.github.koogcompose.provider.ProviderRuntimeRegistry
+import io.github.koogcompose.session.AIResponseChunk
+import io.github.koogcompose.session.Attachment
+import io.github.koogcompose.session.ChatMessage
+import io.github.koogcompose.session.KoogComposeContext
+import io.github.koogcompose.session.MessageRole
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Bridges [ProviderConfig.OnDevice] into the standard [AIProvider] contract.
+ *
+ * Install once at app startup via [installOnDeviceProviderSupport] so
+ * `rememberChatState(context)` can resolve `provider { onDevice(...) }`.
+ */
+public class OnDeviceAIProvider(
+) : AIProvider {
+    override fun <S> stream(
+        context: KoogComposeContext<S>,
+        history: List<ChatMessage>,
+        systemPrompt: String,
+        attachments: List<Attachment>,
+    ): Flow<AIResponseChunk> = flow {
+        val config = context.providerConfig as? ProviderConfig.OnDevice
+            ?: error("OnDeviceAIProvider requires ProviderConfig.OnDevice")
+
+        if (attachments.isNotEmpty()) {
+            val fallback = fallbackProvider(context, config)
+            if (fallback != null) {
+                emitAll(fallback.stream(context, history, systemPrompt, attachments))
+                return@flow
+            }
+            emit(
+                AIResponseChunk.Error(
+                    "On-device provider does not support attachments yet. " +
+                        "Configure onUnavailable { ... } for a multimodal fallback."
+                )
+            )
+            return@flow
+        }
+
+        val provider = OnDeviceProvider(
+            modelPath = config.modelPath,
+            tools = context.resolveEffectiveTools(),
+            maxToolRounds = config.maxToolRounds,
+        )
+        val effectiveTools = context.resolveEffectiveTools()
+
+        try {
+            if (!provider.isAvailable()) {
+                val fallback = fallbackProvider(context, config)
+                if (fallback != null) {
+                    emitAll(fallback.stream(context, history, systemPrompt, attachments))
+                } else {
+                    emit(
+                        AIResponseChunk.Error(
+                            "On-device model is unavailable on this platform/device and no fallback provider is configured."
+                        )
+                    )
+                }
+                return@flow
+            }
+
+            if (effectiveTools.isNotEmpty() && !provider.supportsToolCalls()) {
+                val fallback = fallbackProvider(context, config)
+                if (fallback != null) {
+                    emitAll(fallback.stream(context, history, systemPrompt, attachments))
+                } else {
+                    emit(
+                        AIResponseChunk.Error(
+                            "On-device provider is available, but this platform bridge does not support tool calling yet."
+                        )
+                    )
+                }
+                return@flow
+            }
+
+            val prompt = buildOnDevicePrompt(systemPrompt, history)
+            emitAll(provider.executeStreaming(prompt).asResponseChunks())
+        } finally {
+            provider.close()
+        }
+    }
+
+    private fun <S> fallbackProvider(
+        context: KoogComposeContext<S>,
+        config: ProviderConfig.OnDevice,
+    ): AIProvider? = config.fallback?.let { fallback ->
+        context.copy(providerConfig = fallback).createProvider()
+    }
+}
+
+public fun installOnDeviceProviderSupport() {
+    OnDeviceProviderRuntimeSupport.install()
+}
+
+private object OnDeviceProviderRuntimeSupport {
+    private var installed: Boolean = false
+
+    fun install() {
+        if (installed) return
+        installed = true
+        ProviderRuntimeRegistry.register { context ->
+            if (context.providerConfig is ProviderConfig.OnDevice) {
+                OnDeviceAIProvider()
+            } else {
+                null
+            }
+        }
+    }
+}
+
+private fun buildOnDevicePrompt(
+    systemPrompt: String,
+    history: List<ChatMessage>,
+): OnDevicePrompt {
+    val transcript = history.joinToString("\n\n") { message ->
+        val role = when (message.role) {
+            MessageRole.USER -> "User"
+            MessageRole.ASSISTANT -> "Assistant"
+            MessageRole.SYSTEM -> "System"
+            MessageRole.TOOL -> {
+                val toolName = message.toolName ?: "tool"
+                val toolKind = message.toolKind?.name?.lowercase() ?: "message"
+                "Tool[$toolName/$toolKind]"
+            }
+        }
+        "$role: ${message.content}"
+    }
+    return OnDevicePrompt(
+        system = systemPrompt,
+        user = transcript,
+    )
+}
+
+private fun Flow<String>.asResponseChunks(): Flow<AIResponseChunk> = flow {
+    collect { chunk ->
+        emit(AIResponseChunk.TextDelta(chunk))
+    }
+    emit(AIResponseChunk.End)
+}

--- a/koog-compose-mediapipe/src/commonMain/kotlin/io/github/koogcompose/provider/ondevice/OnDeviceProvider.kt
+++ b/koog-compose-mediapipe/src/commonMain/kotlin/io/github/koogcompose/provider/ondevice/OnDeviceProvider.kt
@@ -1,0 +1,78 @@
+package io.github.koogcompose.provider.ondevice
+
+import io.github.koogcompose.tool.SecureTool
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Platform-agnostic on-device LLM provider.
+ *
+ * ## Android (LiteRT-LM / Gemma 4)
+ * Requires a local `.litertlm` model file. The model must support function calling
+ * (e.g. `gemma-4-E2B-it` or `gemma-4-E4B-it`). Tool dispatch is handled by
+ * koog-compose — LiteRT-LM's automatic tool calling is disabled so that
+ * [SecureTool] validation, guardrails, and retry logic remain active.
+ *
+ * **Known model limitations on Gemma 4 edge variants:**
+ * - Complex multi-step reasoning may degrade on E2B (2B parameters).
+ * - Math and code generation are not primary use cases.
+ * - World knowledge has a training cutoff; do not use for real-time facts.
+ * - Ideal for: device orchestration, natural language → device API, coaching flows.
+ *
+ * ## iOS (Apple Foundation Models) — upcoming
+ * No model path needed. The ~3B parameter model is built into iOS 26+.
+ * Apple Intelligence must be enabled on the device.
+ *
+ * ## Desktop
+ * Not supported by this module. Use Ollama or a cloud provider instead.
+ *
+ * @param modelPath Path to the `.litertlm` model file (Android only; ignored on iOS).
+ * @param tools List of [SecureTool] instances to register with the model.
+ *              Each tool goes through koog's validation + guardrail pipeline.
+ * @param maxToolRounds Maximum agentic loop iterations before returning a
+ *                      partial result. Prevents infinite loops on misbehaving models.
+ *                      Defaults to 5, matching LiteRT-LM's RECURRING_TOOL_CALL_LIMIT.
+ */
+public expect class OnDeviceProvider(
+    modelPath: String = "",
+    tools: List<SecureTool> = emptyList(),
+    maxToolRounds: Int = 5,
+) {
+    /**
+     * Returns true if the on-device model is available and ready to use on this device.
+     *
+     * On Android: checks that [modelPath] exists and the engine can be initialised.
+     * On iOS: currently returns false until the Foundation Models bridge is implemented.
+     * On Desktop: returns false.
+     */
+    public fun isAvailable(): Boolean
+
+    /** Returns true when this platform implementation can execute tool calls inline. */
+    public fun supportsToolCalls(): Boolean
+
+    /**
+     * Runs a full prompt → response cycle, executing any tool calls the model
+     * requests along the way. Suspends until a final non-tool-call response is
+     * returned or [maxToolRounds] is exhausted.
+     */
+    public suspend fun execute(prompt: OnDevicePrompt): String
+
+    /**
+     * Streams tokens as they are decoded. Tool call mid-stream tokens are
+     * consumed internally; only final response tokens are emitted to the caller.
+     */
+    public fun executeStreaming(prompt: OnDevicePrompt): Flow<String>
+
+    /** Releases the underlying engine. Call when the provider is no longer needed. */
+    public fun close()
+}
+
+/**
+ * Prompt container for on-device inference.
+ *
+ * @param system Optional system instruction injected before the conversation.
+ * @param user The user turn text.
+ */
+public data class OnDevicePrompt(
+    val system: String? = null,
+    val user: String,
+)

--- a/koog-compose-mediapipe/src/desktopMain/kotlin/io/github/koogcompose/provider/ondevice/OnDeviceProvider.desktop.kt
+++ b/koog-compose-mediapipe/src/desktopMain/kotlin/io/github/koogcompose/provider/ondevice/OnDeviceProvider.desktop.kt
@@ -1,0 +1,36 @@
+package io.github.koogcompose.provider.ondevice
+
+import io.github.koogcompose.tool.SecureTool
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Desktop stub for OnDeviceProvider.
+ *
+ * LiteRT-LM integration in this module is Android-only, and Apple Foundation
+ * Models are iOS-only. Desktop consumers should use a cloud provider or a
+ * desktop-local provider such as Ollama instead.
+ */
+public actual class OnDeviceProvider public actual constructor(
+    modelPath: String,
+    tools: List<SecureTool>,
+    maxToolRounds: Int,
+) {
+    public actual fun isAvailable(): Boolean = false
+    public actual fun supportsToolCalls(): Boolean = false
+
+    public actual suspend fun execute(prompt: OnDevicePrompt): String {
+        error(
+            "OnDeviceProvider is not supported on desktop in :koog-compose-mediapipe. " +
+                "Use ollama(...) or a cloud provider instead."
+        )
+    }
+
+    public actual fun executeStreaming(prompt: OnDevicePrompt): Flow<String> {
+        error(
+            "OnDeviceProvider is not supported on desktop in :koog-compose-mediapipe. " +
+                "Use ollama(...) or a cloud provider instead."
+        )
+    }
+
+    public actual fun close() {}
+}

--- a/koog-compose-mediapipe/src/iosMain/kotlin/io/github/koogcompose/provider/ondevice/OnDeviceProvider.ios.kt
+++ b/koog-compose-mediapipe/src/iosMain/kotlin/io/github/koogcompose/provider/ondevice/OnDeviceProvider.ios.kt
@@ -1,0 +1,89 @@
+package io.github.koogcompose.provider.ondevice
+
+import io.github.koogcompose.tool.SecureTool
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * iOS stub for OnDeviceProvider.
+ *
+ * Apple Foundation Models integration is not implemented in this library yet.
+ * Even on supported devices, this implementation remains unavailable until a
+ * Swift bridge is added.
+ */
+public actual class OnDeviceProvider public actual constructor(
+    modelPath: String,
+    private val tools: List<SecureTool>,
+    maxToolRounds: Int,
+) {
+    private val bridge: AppleFoundationModelsBridge?
+        get() = AppleFoundationModelsBridgeRegistry.bridge
+
+    public actual fun isAvailable(): Boolean = bridge?.isAvailable() == true
+
+    public actual fun supportsToolCalls(): Boolean = bridge?.supportsToolCalls() == true
+
+    public actual suspend fun execute(prompt: OnDevicePrompt): String {
+        val runtimeBridge = requireBridge()
+        if (tools.isNotEmpty() && !runtimeBridge.supportsToolCalls()) {
+            error(
+                "The installed Apple Foundation Models bridge does not support tool calling yet. " +
+                    "Configure onUnavailable { ... } for tool-using phases."
+            )
+        }
+        return suspendCancellableCoroutine { continuation ->
+            runtimeBridge.execute(
+                systemPrompt = prompt.system,
+                userPrompt = prompt.user,
+            ) { result, error ->
+                when {
+                    error != null -> continuation.resumeWithException(IllegalStateException(error))
+                    result != null -> continuation.resume(result)
+                    else -> continuation.resume("")
+                }
+            }
+        }
+    }
+
+    public actual fun executeStreaming(prompt: OnDevicePrompt): Flow<String> {
+        val runtimeBridge = requireBridge()
+        return callbackFlow {
+            if (tools.isNotEmpty() && !runtimeBridge.supportsToolCalls()) {
+                close(
+                    IllegalStateException(
+                        "The installed Apple Foundation Models bridge does not support tool calling yet. " +
+                            "Configure onUnavailable { ... } for tool-using phases."
+                    )
+                )
+                return@callbackFlow
+            }
+
+            runtimeBridge.stream(
+                systemPrompt = prompt.system,
+                userPrompt = prompt.user,
+                onToken = { token -> trySend(token) },
+                onComplete = { error ->
+                    if (error != null) {
+                        close(IllegalStateException(error))
+                    } else {
+                        close()
+                    }
+                },
+            )
+
+            awaitClose {}
+        }
+    }
+
+    public actual fun close() {}
+
+    private fun requireBridge(): AppleFoundationModelsBridge =
+        bridge ?: error(
+            "No Apple Foundation Models bridge is installed. " +
+                "Call installOnDeviceBridges(...) from Swift app startup."
+        )
+}

--- a/sample-app/src/androidMain/kotlin/io/github/koogcompose/sample/MathTutorApp.kt
+++ b/sample-app/src/androidMain/kotlin/io/github/koogcompose/sample/MathTutorApp.kt
@@ -283,8 +283,8 @@ private fun MathTutorScreen(
                 leadingActions = {
                     // Camera button
                     androidx.compose.material3.IconButton(onClick = onCameraClick) {
-                        androidx.compose.material3.Icon(
-                            androidx.compose.material.icons.Icons.Default.PhotoCamera,
+                        Icon(
+                            Icons.Default.Camera,
                             contentDescription = "Take photo of math problem",
                         )
                     }


### PR DESCRIPTION


- Add ProviderConfig.OnDevice with DSL builder (maxToolRounds, onUnavailable fallback)
- Implement ProviderRuntimeRegistry for pluggable AIProvider factories
- Scope phase-local and transition tools to subgraphs instead of global registry
- Deduplicate resolveEffectiveTools() by SecureTool::name to prevent conflicts
- Add Apple Foundation Models bridge for iOS 26+ (streaming + sync)
- Expand koog-compose-mediapipe to Android, iOS, and Desktop targets
- Add LiteRT-LM tool orchestrator and SecureTool adapter for Android
- Update README with on-device provider docs, provider config section, and v1.3.0 changelog
- Fix sample app icon references (Camera instead of PhotoCamera)