### PR TITLE
Add agent-driven layout engine with policy-based directive processing

### DIFF
--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/AgentLayoutDirective.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/AgentLayoutDirective.kt
@@ -1,0 +1,177 @@
+package io.github.koogcompose.layout
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.jvm.JvmInline
+
+/** Stable identifier for a single directive emission, used for tracing and correlation. */
+@JvmInline
+public value class DirectiveId(public val value: String) {
+    init { require(value.isNotBlank()) { "DirectiveId must not be blank" } }
+}
+
+/**
+ * Insertion position within a multi-component slot.
+ *
+ * - [Start] / [End]: relative to current contents.
+ * - [Index]: absolute zero-based index, clamped to slot size at reduction time.
+ * - [Before] / [After]: relative to a reference component; falls back to [End] if absent.
+ */
+public sealed class Position {
+    public data object Start : Position()
+    public data object End : Position()
+    public data class Index(public val index: Int) : Position() {
+        init { require(index >= 0) { "Position.Index must be non-negative" } }
+    }
+    public data class Before(public val reference: ComponentId) : Position()
+    public data class After(public val reference: ComponentId) : Position()
+}
+
+/** How a component is locked in place. Visible to the user, unlike permission denials. */
+public enum class LockMode { ReadOnly, Disabled, Hidden }
+
+/**
+ * Sealed hierarchy of mutations the agent can propose to the layout.
+ *
+ * Each subtype is a declarative DELTA asserting desired end-state, not an imperative
+ * command. The vocabulary is intentionally small (5 subtypes) for reliable emission
+ * from on-device models. All directives are idempotent at the reducer level — replay
+ * is safe.
+ *
+ * Every directive carries a [correlationId] so the agent can match its emissions to
+ * the [DirectiveOutcome]s it receives in the next turn.
+ */
+public sealed class AgentLayoutDirective {
+    public abstract val correlationId: DirectiveId
+    public abstract val issuedAt: Instant
+    public abstract val reason: String?
+
+    /**
+     * Asserts [componentId] should be visible in [slotId] at [position].
+     *
+     * Semantics: already in slot → reorder; in different slot → move; not shown → add.
+     */
+    public data class ShowComponent(
+        public val componentId: ComponentId,
+        public val slotId: SlotId,
+        public val position: Position = Position.End,
+        public val props: ComponentProps = ComponentProps.Empty,
+        override val correlationId: DirectiveId,
+        override val issuedAt: Instant = Clock.System.now(),
+        override val reason: String? = null,
+    ) : AgentLayoutDirective()
+
+    /**
+     * Asserts [componentId] should not be visible.
+     *
+     * If [slotId] is non-null, removes from that slot only. If null, removes from all slots.
+     */
+    public data class HideComponent(
+        public val componentId: ComponentId,
+        public val slotId: SlotId? = null,
+        override val correlationId: DirectiveId,
+        override val issuedAt: Instant = Clock.System.now(),
+        override val reason: String? = null,
+    ) : AgentLayoutDirective()
+
+    /**
+     * Asserts an explicit ordering for components within [slotId].
+     *
+     * Components in [orderedComponentIds] not currently in the slot are ignored (this
+     * directive does not add). Components currently in the slot but absent from
+     * [orderedComponentIds] keep their relative order, appended after the explicit set.
+     */
+    public data class ReorderComponents(
+        public val slotId: SlotId,
+        public val orderedComponentIds: List<ComponentId>,
+        override val correlationId: DirectiveId,
+        override val issuedAt: Instant = Clock.System.now(),
+        override val reason: String? = null,
+    ) : AgentLayoutDirective()
+
+    /**
+     * Atomically replaces [removeComponentId] with [insertComponentId] in [slotId].
+     *
+     * Rejected (not silently converted) if [removeComponentId] is not in the slot,
+     * because the agent's intent was specifically a swap.
+     */
+    public data class SwapComponent(
+        public val slotId: SlotId,
+        public val removeComponentId: ComponentId,
+        public val insertComponentId: ComponentId,
+        public val props: ComponentProps = ComponentProps.Empty,
+        override val correlationId: DirectiveId,
+        override val issuedAt: Instant = Clock.System.now(),
+        override val reason: String? = null,
+    ) : AgentLayoutDirective()
+
+    /**
+     * Applies [lockMode] to [componentId] in [slotId].
+     *
+     * Policy can strengthen a lock but never weaken it. Rejected if the component is
+     * not currently in the slot.
+     */
+    public data class LockComponent(
+        public val componentId: ComponentId,
+        public val slotId: SlotId,
+        public val lockMode: LockMode,
+        override val correlationId: DirectiveId,
+        override val issuedAt: Instant = Clock.System.now(),
+        override val reason: String? = null,
+    ) : AgentLayoutDirective()
+}
+
+/** Where in the system a state change originated. */
+public enum class DirectiveSource { Agent, Policy, UserAction, Default, Restore }
+
+/**
+ * Result of a directive's trip through the pipeline. Published to the outcomes flow
+ * the agent reads in subsequent turns. The Compose UI only consumes [LayoutState].
+ */
+public sealed class DirectiveOutcome {
+    public abstract val correlationId: DirectiveId
+    public abstract val resultingStateVersion: Long?
+
+    /** Directive applied as-is. */
+    public data class Accepted(
+        override val correlationId: DirectiveId,
+        override val resultingStateVersion: Long,
+    ) : DirectiveOutcome()
+
+    /**
+     * Directive was modified before application. Common rewrites: evict-then-show on
+     * Single slots; agent-issued ReadOnly lock upgraded by policy to Hidden.
+     */
+    public data class Rewritten(
+        override val correlationId: DirectiveId,
+        public val original: AgentLayoutDirective,
+        public val final: AgentLayoutDirective,
+        public val reason: String,
+        override val resultingStateVersion: Long,
+    ) : DirectiveOutcome()
+
+    /** Directive dropped entirely. State is unchanged. */
+    public data class Rejected(
+        override val correlationId: DirectiveId,
+        public val reason: String,
+        public val rejectedAt: PipelineStage,
+    ) : DirectiveOutcome() {
+        override val resultingStateVersion: Long? get() = null
+    }
+
+    /** Directive deduped against another in-flight directive in the coalescing window. */
+    public data class Coalesced(
+        override val correlationId: DirectiveId,
+        public val coalescedWith: DirectiveId,
+    ) : DirectiveOutcome() {
+        override val resultingStateVersion: Long? get() = null
+    }
+}
+
+/** Stage at which a directive was rejected. */
+public enum class PipelineStage {
+    SchemaValidation,
+    PolicyCheck,
+    SlotConstraintCheck,
+    Reduce,
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutDirectiveProcessor.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutDirectiveProcessor.kt
@@ -1,0 +1,172 @@
+package io.github.koogcompose.layout
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Processes [AgentLayoutDirective]s in FIFO order and publishes [DirectiveOutcome]s.
+ *
+ * Callers emit directives via [send] (fire-and-forget) and observe live layout
+ * state via [layoutState]. The agent reads back [outcomes] in subsequent turns
+ * to learn whether its directives were accepted, rewritten, rejected, or coalesced.
+ */
+public interface LayoutDirectiveProcessor {
+    /** Live, immediately consistent snapshot of the current layout. */
+    public val layoutState: StateFlow<LayoutState>
+
+    /** Hot stream of outcomes — one per processed directive. */
+    public val outcomes: SharedFlow<DirectiveOutcome>
+
+    /** Queue a directive for processing. Returns immediately (non-suspending). */
+    public fun send(directive: AgentLayoutDirective)
+
+    /**
+     * Signal the start of a new agent turn. Clears in-flight coalescing state so
+     * the same [DirectiveId] can be re-used across turns without being dropped.
+     *
+     * Called by [io.github.koogcompose.session.PhaseSession] at the top of every
+     * [io.github.koogcompose.session.PhaseSession.send] invocation.
+     */
+    public fun beginTurn()
+}
+
+/**
+ * Configuration bundle required to build a [DefaultLayoutDirectiveProcessor].
+ *
+ * Registered in [io.github.koogcompose.session.KoogComposeContext] at session
+ * initialization and passed into the processor when the session scope is ready.
+ */
+public data class LayoutEngineConfig(
+    val workflowContext: WorkflowContext,
+    val slotRegistry: SlotRegistry,
+    val componentRegistry: ComponentRegistry,
+    /** Host / workflow policy tiers applied after the built-in [SdkLayoutPolicy]. */
+    val policy: LayoutPolicy = LayoutPolicyChain.Empty,
+)
+
+/**
+ * Single-threaded actor implementation of [LayoutDirectiveProcessor].
+ *
+ * All mutations — both [send] directives and [beginTurn] signals — funnel through
+ * a single [Channel.UNLIMITED] channel consumed by one coroutine in [scope].
+ * This guarantees that [LayoutState] and the deduplication set are mutated
+ * sequentially without any external locks.
+ *
+ * Policy chain assembled at construction: [SdkLayoutPolicy] → host [LayoutEngineConfig.policy].
+ */
+public class DefaultLayoutDirectiveProcessor(
+    private val config: LayoutEngineConfig,
+    scope: CoroutineScope,
+    initialState: LayoutState = LayoutState.Empty,
+) : LayoutDirectiveProcessor {
+
+    // ── Actor message types ────────────────────────────────────────────────
+
+    private sealed interface ActorMessage
+    private data class Emit(val directive: AgentLayoutDirective) : ActorMessage
+    private data object BeginTurn : ActorMessage
+
+    // ── Policy ─────────────────────────────────────────────────────────────
+
+    private val sdkPolicy = SdkLayoutPolicy(config.slotRegistry, config.componentRegistry)
+    private val effectivePolicy: LayoutPolicy = LayoutPolicyChain(
+        buildList {
+            add(sdkPolicy)
+            if (config.policy != LayoutPolicyChain.Empty) add(config.policy)
+        }
+    )
+
+    // ── Observable state ───────────────────────────────────────────────────
+
+    private val _layoutState = MutableStateFlow(initialState)
+    override val layoutState: StateFlow<LayoutState> = _layoutState.asStateFlow()
+
+    private val _outcomes = MutableSharedFlow<DirectiveOutcome>(extraBufferCapacity = 64)
+    override val outcomes: SharedFlow<DirectiveOutcome> = _outcomes.asSharedFlow()
+
+    // ── Actor channel ──────────────────────────────────────────────────────
+
+    private val channel = Channel<ActorMessage>(Channel.UNLIMITED)
+
+    /** Correlation IDs seen in the current turn — reset by [BeginTurn] messages. */
+    private val inFlightIds = mutableSetOf<DirectiveId>()
+
+    init {
+        scope.launch {
+            for (message in channel) {
+                when (message) {
+                    is BeginTurn -> inFlightIds.clear()
+                    is Emit      -> processOne(message.directive)
+                }
+            }
+        }
+    }
+
+    override fun send(directive: AgentLayoutDirective) {
+        channel.trySend(Emit(directive))
+    }
+
+    override fun beginTurn() {
+        channel.trySend(BeginTurn)
+    }
+
+    private suspend fun processOne(directive: AgentLayoutDirective) {
+        // Within-turn deduplication: same correlationId → Coalesced outcome.
+        if (directive.correlationId in inFlightIds) {
+            _outcomes.emit(
+                DirectiveOutcome.Coalesced(
+                    correlationId = directive.correlationId,
+                    coalescedWith = directive.correlationId,
+                )
+            )
+            return
+        }
+        inFlightIds += directive.correlationId
+
+        val state = _layoutState.value
+        when (val decision = effectivePolicy.evaluate(directive, state, config.workflowContext)) {
+            is PolicyDecision.Allow -> {
+                val newState = LayoutReducer.apply(state, directive, config.slotRegistry)
+                _layoutState.value = newState
+                _outcomes.emit(
+                    DirectiveOutcome.Accepted(
+                        correlationId = directive.correlationId,
+                        resultingStateVersion = newState.version,
+                    )
+                )
+            }
+
+            is PolicyDecision.Rewrite -> {
+                val finalDirective = decision.replacement
+                val newState = LayoutReducer.apply(state, finalDirective, config.slotRegistry)
+                _layoutState.value = newState
+                _outcomes.emit(
+                    DirectiveOutcome.Rewritten(
+                        correlationId = directive.correlationId,
+                        original = directive,
+                        final = finalDirective,
+                        reason = decision.reason,
+                        resultingStateVersion = newState.version,
+                    )
+                )
+            }
+
+            is PolicyDecision.Deny -> {
+                _outcomes.emit(
+                    DirectiveOutcome.Rejected(
+                        correlationId = directive.correlationId,
+                        reason = decision.reason,
+                        rejectedAt = decision.stage,
+                    )
+                )
+            }
+        }
+    }
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutPolicy.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutPolicy.kt
@@ -1,0 +1,234 @@
+package io.github.koogcompose.layout
+
+/**
+ * A single policy tier that can approve, rewrite, or reject a layout directive.
+ *
+ * Three tiers are assembled in priority order:
+ *   SDK ([SdkLayoutPolicy]) → Host (registered at startup) → Workflow (optional per-workflow).
+ * All tiers are chained via [LayoutPolicyChain].
+ */
+public interface LayoutPolicy {
+    /**
+     * Evaluate [directive] against the current [state] and [context].
+     *
+     * Return [PolicyDecision.Allow] to pass the directive unchanged, [PolicyDecision.Rewrite]
+     * to substitute a modified directive, or [PolicyDecision.Deny] to reject it entirely.
+     */
+    public fun evaluate(
+        directive: AgentLayoutDirective,
+        state: LayoutState,
+        context: WorkflowContext,
+    ): PolicyDecision
+}
+
+/** The outcome of a single policy tier's evaluation. */
+public sealed class PolicyDecision {
+    public data object Allow : PolicyDecision()
+
+    public data class Rewrite(
+        val replacement: AgentLayoutDirective,
+        val reason: String,
+    ) : PolicyDecision()
+
+    public data class Deny(
+        val reason: String,
+        val stage: PipelineStage = PipelineStage.PolicyCheck,
+    ) : PolicyDecision()
+}
+
+/**
+ * Chains multiple [LayoutPolicy] instances in order. First Deny short-circuits.
+ * First Rewrite is applied and subsequent policies evaluate the rewritten directive.
+ */
+public class LayoutPolicyChain(
+    internal val policies: List<LayoutPolicy>,
+) : LayoutPolicy {
+
+    override fun evaluate(
+        directive: AgentLayoutDirective,
+        state: LayoutState,
+        context: WorkflowContext,
+    ): PolicyDecision {
+        var current: AgentLayoutDirective = directive
+        var rewritten = false
+        var rewriteReason = ""
+
+        for (policy in policies) {
+            when (val decision = policy.evaluate(current, state, context)) {
+                is PolicyDecision.Allow  -> continue
+                is PolicyDecision.Deny   -> return decision
+                is PolicyDecision.Rewrite -> {
+                    current = decision.replacement
+                    rewritten = true
+                    rewriteReason = decision.reason
+                }
+            }
+        }
+
+        return if (rewritten) PolicyDecision.Rewrite(current, rewriteReason)
+        else PolicyDecision.Allow
+    }
+
+    public companion object {
+        public val Empty: LayoutPolicyChain = LayoutPolicyChain(emptyList())
+    }
+}
+
+/**
+ * SDK-tier built-in policy. Enforces schema validity, tag compatibility,
+ * permission requirements, and lock-strengthening rules.
+ *
+ * This is always the first policy in the chain assembled by
+ * [DefaultLayoutDirectiveProcessor] — host and workflow policies run after.
+ */
+public class SdkLayoutPolicy(
+    private val slotRegistry: SlotRegistry,
+    private val componentRegistry: ComponentRegistry,
+) : LayoutPolicy {
+
+    override fun evaluate(
+        directive: AgentLayoutDirective,
+        state: LayoutState,
+        context: WorkflowContext,
+    ): PolicyDecision = when (directive) {
+        is AgentLayoutDirective.ShowComponent     -> validateShow(directive, context)
+        is AgentLayoutDirective.HideComponent     -> validateHide(directive)
+        is AgentLayoutDirective.ReorderComponents -> validateSlot(directive.slotId)
+        is AgentLayoutDirective.SwapComponent     -> validateSwap(directive, state, context)
+        is AgentLayoutDirective.LockComponent     -> validateLock(directive, state)
+    }
+
+    private fun validateShow(
+        d: AgentLayoutDirective.ShowComponent,
+        ctx: WorkflowContext,
+    ): PolicyDecision {
+        val slot = slotRegistry[d.slotId]
+            ?: return PolicyDecision.Deny(
+                "Unknown slot '${d.slotId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        val component = componentRegistry[d.componentId]
+            ?: return PolicyDecision.Deny(
+                "Unknown component '${d.componentId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        if (component.tags.none { it in slot.allowedComponentTags }) {
+            return PolicyDecision.Deny(
+                "Component '${d.componentId.value}' has no tag matching slot '${d.slotId.value}'",
+                PipelineStage.SlotConstraintCheck,
+            )
+        }
+        if (!ctx.userRole.permissions.containsAll(component.requiredPermissions)) {
+            return PolicyDecision.Deny(
+                "Insufficient permissions to show '${d.componentId.value}'",
+                PipelineStage.PolicyCheck,
+            )
+        }
+        return PolicyDecision.Allow
+    }
+
+    private fun validateHide(d: AgentLayoutDirective.HideComponent): PolicyDecision {
+        if (d.slotId != null && !slotRegistry.contains(d.slotId)) {
+            return PolicyDecision.Deny(
+                "Unknown slot '${d.slotId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        if (!componentRegistry.contains(d.componentId)) {
+            return PolicyDecision.Deny(
+                "Unknown component '${d.componentId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        return PolicyDecision.Allow
+    }
+
+    private fun validateSlot(slotId: SlotId): PolicyDecision {
+        if (!slotRegistry.contains(slotId)) {
+            return PolicyDecision.Deny(
+                "Unknown slot '${slotId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        return PolicyDecision.Allow
+    }
+
+    private fun validateSwap(
+        d: AgentLayoutDirective.SwapComponent,
+        state: LayoutState,
+        ctx: WorkflowContext,
+    ): PolicyDecision {
+        val slot = slotRegistry[d.slotId]
+            ?: return PolicyDecision.Deny(
+                "Unknown slot '${d.slotId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        val insertComponent = componentRegistry[d.insertComponentId]
+            ?: return PolicyDecision.Deny(
+                "Unknown component '${d.insertComponentId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        if (!componentRegistry.contains(d.removeComponentId)) {
+            return PolicyDecision.Deny(
+                "Unknown component '${d.removeComponentId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        if (state.entriesFor(d.slotId).none { it.componentId == d.removeComponentId }) {
+            return PolicyDecision.Deny(
+                "Component '${d.removeComponentId.value}' is not in slot '${d.slotId.value}'",
+                PipelineStage.Reduce,
+            )
+        }
+        if (insertComponent.tags.none { it in slot.allowedComponentTags }) {
+            return PolicyDecision.Deny(
+                "Component '${d.insertComponentId.value}' has no tag matching slot '${d.slotId.value}'",
+                PipelineStage.SlotConstraintCheck,
+            )
+        }
+        if (!ctx.userRole.permissions.containsAll(insertComponent.requiredPermissions)) {
+            return PolicyDecision.Deny(
+                "Insufficient permissions to show '${d.insertComponentId.value}'",
+                PipelineStage.PolicyCheck,
+            )
+        }
+        return PolicyDecision.Allow
+    }
+
+    private fun validateLock(
+        d: AgentLayoutDirective.LockComponent,
+        state: LayoutState,
+    ): PolicyDecision {
+        if (!slotRegistry.contains(d.slotId)) {
+            return PolicyDecision.Deny(
+                "Unknown slot '${d.slotId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        if (!componentRegistry.contains(d.componentId)) {
+            return PolicyDecision.Deny(
+                "Unknown component '${d.componentId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        val entry = state.entriesFor(d.slotId).find { it.componentId == d.componentId }
+            ?: return PolicyDecision.Deny(
+                "Component '${d.componentId.value}' is not in slot '${d.slotId.value}'",
+                PipelineStage.Reduce,
+            )
+        val existing = entry.lockMode
+        if (existing != null && !d.lockMode.isStrongerOrEqualTo(existing)) {
+            return PolicyDecision.Deny(
+                "Cannot weaken lock from $existing to ${d.lockMode} — policy can only strengthen locks",
+                PipelineStage.PolicyCheck,
+            )
+        }
+        return PolicyDecision.Allow
+    }
+}
+
+private fun LockMode.isStrongerOrEqualTo(other: LockMode): Boolean = when (this) {
+    LockMode.ReadOnly -> other == LockMode.ReadOnly
+    LockMode.Disabled -> other == LockMode.ReadOnly || other == LockMode.Disabled
+    LockMode.Hidden   -> true
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutReducer.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutReducer.kt
@@ -1,0 +1,166 @@
+package io.github.koogcompose.layout
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * Pure function: applies [directive] to [state] and returns the new [LayoutState].
+ *
+ * No coroutines, no Compose — designed to be fully unit-testable in isolation.
+ * [slotRegistry] is optional; when provided, [SlotCapacity] constraints are
+ * enforced (Single → replace existing; Multiple(max) → LRU eviction). When
+ * null (useful in tests), capacity is treated as [SlotCapacity.Unbounded].
+ *
+ * Called by [DefaultLayoutDirectiveProcessor] only after all policies pass.
+ * Replay is safe — all subtypes are idempotent.
+ */
+public object LayoutReducer {
+
+    public fun apply(
+        state: LayoutState,
+        directive: AgentLayoutDirective,
+        slotRegistry: SlotRegistry? = null,
+        now: Instant = Clock.System.now(),
+    ): LayoutState = when (directive) {
+        is AgentLayoutDirective.ShowComponent     -> applyShow(state, directive, slotRegistry, now)
+        is AgentLayoutDirective.HideComponent     -> applyHide(state, directive)
+        is AgentLayoutDirective.ReorderComponents -> applyReorder(state, directive)
+        is AgentLayoutDirective.SwapComponent     -> applySwap(state, directive, now)
+        is AgentLayoutDirective.LockComponent     -> applyLock(state, directive)
+    }
+
+    // ── ShowComponent ──────────────────────────────────────────────────────
+
+    private fun applyShow(
+        state: LayoutState,
+        d: AgentLayoutDirective.ShowComponent,
+        slotRegistry: SlotRegistry?,
+        now: Instant,
+    ): LayoutState {
+        val existing = state.slots[d.slotId] ?: emptyList()
+
+        // Reuse the existing entry (preserving addedAt) if the component is already present.
+        val entry = existing.firstOrNull { it.componentId == d.componentId }
+            ?.copy(props = d.props)
+            ?: SlotEntry(componentId = d.componentId, props = d.props, addedAt = now)
+
+        // Remove the target component before re-inserting it at the new position.
+        val withoutTarget = existing.filter { it.componentId != d.componentId }
+
+        // Apply slot-capacity constraints.
+        val capacity = slotRegistry?.get(d.slotId)?.capacity
+        val cappedBase: List<SlotEntry> = when (capacity) {
+            is SlotCapacity.Single    -> emptyList()  // evict any existing occupant
+            is SlotCapacity.Multiple  -> {
+                if (withoutTarget.size >= capacity.max) {
+                    // LRU eviction: the list is insertion-ordered; oldest is first.
+                    withoutTarget.drop(1)
+                } else {
+                    withoutTarget
+                }
+            }
+            is SlotCapacity.Unbounded, null -> withoutTarget
+        }
+
+        val inserted = insertAt(cappedBase, d.position, entry)
+        return state.copy(
+            slots = state.slots + (d.slotId to inserted),
+            version = state.version + 1,
+        )
+    }
+
+    // ── HideComponent ──────────────────────────────────────────────────────
+
+    private fun applyHide(
+        state: LayoutState,
+        d: AgentLayoutDirective.HideComponent,
+    ): LayoutState {
+        val targetSlots: List<SlotId> = if (d.slotId != null) {
+            listOf(d.slotId)
+        } else {
+            state.slots.keys.toList()
+        }
+        var newSlots = state.slots
+        for (slotId in targetSlots) {
+            newSlots = newSlots + (slotId to (newSlots[slotId] ?: emptyList())
+                .filter { it.componentId != d.componentId })
+        }
+        return state.copy(slots = newSlots, version = state.version + 1)
+    }
+
+    // ── ReorderComponents ──────────────────────────────────────────────────
+
+    private fun applyReorder(
+        state: LayoutState,
+        d: AgentLayoutDirective.ReorderComponents,
+    ): LayoutState {
+        val existing = state.slots[d.slotId] ?: return state
+        val byId = existing.associateBy { it.componentId }
+        val orderedSet = d.orderedComponentIds.toSet()
+        val explicit = d.orderedComponentIds.mapNotNull { byId[it] }
+        val rest = existing.filter { it.componentId !in orderedSet }
+        return state.copy(
+            slots = state.slots + (d.slotId to explicit + rest),
+            version = state.version + 1,
+        )
+    }
+
+    // ── SwapComponent ──────────────────────────────────────────────────────
+
+    private fun applySwap(
+        state: LayoutState,
+        d: AgentLayoutDirective.SwapComponent,
+        now: Instant,
+    ): LayoutState {
+        val existing = state.slots[d.slotId] ?: return state
+        val newEntry = SlotEntry(componentId = d.insertComponentId, props = d.props, addedAt = now)
+        val replaced = existing.map { entry ->
+            if (entry.componentId == d.removeComponentId) newEntry else entry
+        }
+        return state.copy(
+            slots = state.slots + (d.slotId to replaced),
+            version = state.version + 1,
+        )
+    }
+
+    // ── LockComponent ──────────────────────────────────────────────────────
+
+    private fun applyLock(
+        state: LayoutState,
+        d: AgentLayoutDirective.LockComponent,
+    ): LayoutState {
+        val existing = state.slots[d.slotId] ?: return state
+        val updated = existing.map { entry ->
+            if (entry.componentId == d.componentId) entry.copy(lockMode = d.lockMode) else entry
+        }
+        return state.copy(
+            slots = state.slots + (d.slotId to updated),
+            version = state.version + 1,
+        )
+    }
+
+    // ── Position helpers ───────────────────────────────────────────────────
+
+    private fun insertAt(
+        base: List<SlotEntry>,
+        position: Position,
+        entry: SlotEntry,
+    ): List<SlotEntry> = when (position) {
+        is Position.Start -> listOf(entry) + base
+        is Position.End   -> base + entry
+        is Position.Index -> {
+            val clamped = position.index.coerceIn(0, base.size)
+            base.toMutableList().apply { add(clamped, entry) }
+        }
+        is Position.Before -> {
+            val idx = base.indexOfFirst { it.componentId == position.reference }
+            if (idx < 0) base + entry
+            else base.toMutableList().apply { add(idx, entry) }
+        }
+        is Position.After -> {
+            val idx = base.indexOfFirst { it.componentId == position.reference }
+            if (idx < 0) base + entry
+            else base.toMutableList().apply { add(idx + 1, entry) }
+        }
+    }
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutSlot.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutSlot.kt
@@ -1,0 +1,169 @@
+package io.github.koogcompose.layout
+
+import kotlin.jvm.JvmInline
+
+/** Stable identifier for a slot — an addressing location the agent targets. */
+@JvmInline
+public value class SlotId(public val value: String) {
+    init { require(value.isNotBlank()) { "SlotId must not be blank" } }
+}
+
+/** Stable identifier for a component — the things that flow through slots. */
+@JvmInline
+public value class ComponentId(public val value: String) {
+    init { require(value.isNotBlank()) { "ComponentId must not be blank" } }
+}
+
+/**
+ * Semantic tag attached to both slots and components. A slot declares which tags it
+ * accepts; only components with at least one matching tag can be placed in it.
+ */
+@JvmInline
+public value class Tag(public val value: String) {
+    init { require(value.isNotBlank()) { "Tag must not be blank" } }
+}
+
+/**
+ * Declares a layout slot. Created by the host app and registered in [SlotRegistry] at
+ * startup. Slots are immutable — adding a new slot requires a new app version.
+ */
+public data class LayoutSlot(
+    public val id: SlotId,
+    public val capacity: SlotCapacity,
+    public val allowedComponentTags: Set<Tag>,
+    public val defaultBehavior: SlotDefault = SlotDefault.Empty,
+) {
+    init {
+        require(allowedComponentTags.isNotEmpty()) {
+            "LayoutSlot ${id.value} must declare at least one allowed tag"
+        }
+    }
+}
+
+/**
+ * How many components a slot can hold simultaneously.
+ *
+ * - [Single]: exactly one; Show into a full slot evicts the existing component.
+ * - [Multiple]: up to [Multiple.max]; Show into a full slot causes LRU eviction.
+ * - [Unbounded]: no cap.
+ */
+public sealed class SlotCapacity {
+    public data object Single : SlotCapacity()
+    public data class Multiple(public val max: Int) : SlotCapacity() {
+        init { require(max >= 2) { "Multiple capacity max must be >= 2; use Single for one" } }
+    }
+    public data object Unbounded : SlotCapacity()
+}
+
+/**
+ * What a slot displays when empty.
+ *
+ * - [Empty]: render nothing.
+ * - [Placeholder]: render the host-provided placeholder composable.
+ * - [FallbackComponent]: render the named component with empty props. Must reference a
+ *   registered component or validation will fail at startup.
+ */
+public sealed class SlotDefault {
+    public data object Empty : SlotDefault()
+    public data object Placeholder : SlotDefault()
+    public data class FallbackComponent(public val componentId: ComponentId) : SlotDefault()
+}
+
+/**
+ * Free-form, immutable bag of properties passed from the agent directive into the
+ * rendered component. Kept as a string map so the serialization boundary is simple
+ * (agent emits JSON strings, component reads what it needs).
+ */
+public data class ComponentProps(
+    public val values: Map<String, String> = emptyMap(),
+) {
+    public companion object {
+        public val Empty: ComponentProps = ComponentProps()
+    }
+
+    public fun get(key: String): String? = values[key]
+    public fun getOrDefault(key: String, default: String): String = values[key] ?: default
+}
+
+/**
+ * Host-app-declared registry of every slot the app supports.
+ * Built at startup, immutable thereafter.
+ */
+public class SlotRegistry(slots: Iterable<LayoutSlot>) {
+    private val slotList = slots.toList()
+    private val bySlotId: Map<SlotId, LayoutSlot> = slotList.associateBy { it.id }.also { map ->
+        require(map.size == slotList.size) { "SlotRegistry contains duplicate SlotIds" }
+    }
+
+    public val all: Collection<LayoutSlot> get() = bySlotId.values
+    public operator fun get(id: SlotId): LayoutSlot? = bySlotId[id]
+    public fun contains(id: SlotId): Boolean = id in bySlotId
+    public fun require(id: SlotId): LayoutSlot =
+        bySlotId[id] ?: throw IllegalArgumentException("Unknown SlotId: ${id.value}")
+}
+
+/**
+ * Host-app-declared registry of every component the agent can reference.
+ * Built at startup, immutable thereafter.
+ *
+ * @param requiredPermissions components are only shown to roles whose
+ *   [UserRole.permissions] is a superset of this set — the first line of defense.
+ */
+public class ComponentRegistry(components: Iterable<ComponentDefinition>) {
+    private val componentList = components.toList()
+    private val byId: Map<ComponentId, ComponentDefinition> =
+        componentList.associateBy { it.id }.also { map ->
+            require(map.size == componentList.size) {
+                "ComponentRegistry contains duplicate ComponentIds"
+            }
+        }
+
+    public val all: Collection<ComponentDefinition> get() = byId.values
+    public operator fun get(id: ComponentId): ComponentDefinition? = byId[id]
+    public fun contains(id: ComponentId): Boolean = id in byId
+    public fun require(id: ComponentId): ComponentDefinition =
+        byId[id] ?: throw IllegalArgumentException("Unknown ComponentId: ${id.value}")
+
+    /**
+     * Cross-validates this registry against a [SlotRegistry]: every
+     * [SlotDefault.FallbackComponent] must reference a registered component whose tags
+     * intersect the slot's [LayoutSlot.allowedComponentTags].
+     *
+     * Call once at startup after both registries are built. Throws on the first violation.
+     */
+    public fun validateAgainst(slotRegistry: SlotRegistry) {
+        slotRegistry.all.forEach { slot ->
+            val default = slot.defaultBehavior
+            if (default is SlotDefault.FallbackComponent) {
+                val component = byId[default.componentId]
+                    ?: error(
+                        "Slot '${slot.id.value}' declares fallback component " +
+                            "'${default.componentId.value}' which is not registered."
+                    )
+                require(component.tags.any { it in slot.allowedComponentTags }) {
+                    "Fallback component '${component.id.value}' for slot '${slot.id.value}' " +
+                        "has no tag matching the slot's allowed tags."
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Metadata for a component the agent can place. The [content] composable is resolved
+ * by [io.github.koogcompose.layout.ui.LayoutHost] at render time via a
+ * [ComponentContentProvider] registered in the UI layer.
+ *
+ * Keeping component metadata separate from the composable lambda lets the engine files
+ * remain Compose-free and fully unit-testable.
+ */
+public data class ComponentDefinition(
+    public val id: ComponentId,
+    public val tags: Set<Tag>,
+    public val requiredPermissions: Set<Permission> = emptySet(),
+) {
+    init { require(tags.isNotEmpty()) { "ComponentDefinition ${id.value} must declare at least one tag" } }
+
+    override fun equals(other: Any?): Boolean = other is ComponentDefinition && other.id == id
+    override fun hashCode(): Int = id.hashCode()
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutState.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutState.kt
@@ -1,0 +1,40 @@
+package io.github.koogcompose.layout
+
+import kotlinx.datetime.Instant
+
+/**
+ * Immutable snapshot of a single component's occupancy in a slot.
+ *
+ * [addedAt] records when the component was placed; used for LRU eviction in
+ * [SlotCapacity.Multiple] slots. [lockMode] is non-null only once a
+ * [AgentLayoutDirective.LockComponent] has been applied.
+ */
+public data class SlotEntry(
+    val componentId: ComponentId,
+    val props: ComponentProps,
+    val lockMode: LockMode? = null,
+    val addedAt: Instant,
+)
+
+/**
+ * Immutable snapshot of the entire agent-driven layout.
+ *
+ * Each value in [slots] is the ordered list of [SlotEntry] items currently
+ * occupying that slot. Slots not yet touched by any directive are absent from
+ * the map (check [entriesFor] for a safe accessor).
+ *
+ * [version] is a monotonically-increasing counter that increments on every
+ * successful directive application. The Compose UI can use it as a cheap
+ * change signal without deep structural comparison.
+ */
+public data class LayoutState(
+    val slots: Map<SlotId, List<SlotEntry>> = emptyMap(),
+    val version: Long = 0L,
+) {
+    public fun entriesFor(slotId: SlotId): List<SlotEntry> = slots[slotId] ?: emptyList()
+    public fun isEmpty(): Boolean = slots.all { it.value.isEmpty() }
+
+    public companion object {
+        public val Empty: LayoutState = LayoutState()
+    }
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/WorkflowContext.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/WorkflowContext.kt
@@ -1,0 +1,87 @@
+package io.github.koogcompose.layout
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Immutable, session-scoped context describing WHO is using the app and WHAT workflow
+ * they are running. Passed to [io.github.koogcompose.session.KoogComposeContext] at
+ * session initialization and never mutated for the lifetime of the session.
+ *
+ * The combination of [businessId] + [activeWorkflow] is what the cloud config layer
+ * (Layer 3) uses to look up the appropriate WorkflowDefinition.
+ */
+public data class WorkflowContext(
+    public val businessId: BusinessId,
+    public val userRole: UserRole,
+    public val activeWorkflow: WorkflowId,
+    public val deviceContext: DeviceContext,
+    public val sessionMetadata: Map<String, String> = emptyMap(),
+)
+
+@JvmInline
+public value class BusinessId(public val value: String) {
+    init { require(value.isNotBlank()) { "BusinessId must not be blank" } }
+}
+
+@JvmInline
+public value class WorkflowId(public val value: String) {
+    init { require(value.isNotBlank()) { "WorkflowId must not be blank" } }
+}
+
+/**
+ * Typed user role. Host apps subclass this once at startup and register every role
+ * they support. The [permissions] set is the authoritative grant consulted by the
+ * policy layer on every directive.
+ *
+ * Roles do not change mid-session. If a user's role changes, the host app starts a
+ * new session with a new [WorkflowContext].
+ */
+public abstract class UserRole(
+    public val id: String,
+    public val displayName: String,
+    public val permissions: Set<Permission>,
+) {
+    init { require(id.isNotBlank()) { "UserRole.id must not be blank" } }
+
+    final override fun equals(other: Any?): Boolean = other is UserRole && other.id == id
+    final override fun hashCode(): Int = id.hashCode()
+    final override fun toString(): String = "UserRole($id)"
+}
+
+/**
+ * A capability grant. Components carry [ComponentSpec.requiredPermissions] which the
+ * policy layer compares against [UserRole.permissions].
+ */
+@JvmInline
+public value class Permission(public val name: String) {
+    init { require(name.isNotBlank()) { "Permission.name must not be blank" } }
+}
+
+/** Conventional permissions the SDK uses for its own engine-level checks. */
+public object Permissions {
+    public val Read: Permission = Permission("koog.read")
+    public val Write: Permission = Permission("koog.write")
+    public val Admin: Permission = Permission("koog.admin")
+}
+
+/**
+ * Snapshot of the device the session is running on. Used by the agent to reason about
+ * what UI is appropriate (denser layouts on tablets, simpler layouts when offline, etc.).
+ */
+public data class DeviceContext(
+    public val platform: Platform,
+    public val formFactor: FormFactor,
+    public val networkClass: NetworkClass,
+    public val locale: String,
+)
+
+public enum class Platform { Android, IOS, Desktop, Web }
+
+public enum class FormFactor { Phone, Tablet, Desktop }
+
+/**
+ * Coarse-grained network classification. Important for markets where degraded/offline
+ * operation is common — the agent reads this to decide whether to attempt cloud-bound
+ * directives or stay strictly on-device.
+ */
+public enum class NetworkClass { Online, Degraded, Offline }

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/KoogComposeContext.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/KoogComposeContext.kt
@@ -1,6 +1,12 @@
 package io.github.koogcompose.session
 
 import io.github.koogcompose.event.EventHandlers
+import io.github.koogcompose.layout.LayoutEngineConfig
+import io.github.koogcompose.layout.LayoutPolicy
+import io.github.koogcompose.layout.LayoutPolicyChain
+import io.github.koogcompose.layout.SlotRegistry
+import io.github.koogcompose.layout.ComponentRegistry
+import io.github.koogcompose.layout.WorkflowContext
 import io.github.koogcompose.observability.EventSink
 import io.github.koogcompose.observability.NoOpEventSink
 import io.github.koogcompose.phase.Phase
@@ -292,6 +298,7 @@ public data class KoogComposeContext<S>(
     override val stateStore: KoogStateStore<S>?,
     val config: KoogConfig,
     val contextualInstructions: List<ContextualInstruction> = emptyList(),
+    val layoutEngineConfig: LayoutEngineConfig? = null,
 ) : KoogDefinition<S> {
     public fun createProvider(): AIProvider =
         ProviderRuntimeRegistry.create(this) ?: KoogAIProvider(this)
@@ -379,6 +386,7 @@ public data class KoogComposeContext<S>(
         private var eventHandlers: EventHandlers = EventHandlers.Empty
         private var config: KoogConfig = KoogConfig()
         private var contextualInstructions: List<ContextualInstruction> = emptyList()
+        private var layoutEngineConfig: LayoutEngineConfig? = null
 
         public fun provider(block: ProviderConfigBuilder.() -> Unit) {
             providerConfig = ProviderConfigBuilder().apply(block).build()
@@ -430,6 +438,22 @@ public data class KoogComposeContext<S>(
             contextualInstructions = ContextualInstructionsBuilder().apply(block).build()
         }
 
+        /**
+         * Enables the agent-driven layout engine for this session.
+         *
+         * ```kotlin
+         * layout {
+         *     workflowContext = WorkflowContext(...)
+         *     slotRegistry    = SlotRegistry(listOf(...))
+         *     componentRegistry = ComponentRegistry(listOf(...))
+         *     policy { /* optional host/workflow policy tiers */ }
+         * }
+         * ```
+         */
+        public fun layout(block: LayoutEngineConfigBuilder.() -> Unit) {
+            layoutEngineConfig = LayoutEngineConfigBuilder().apply(block).build()
+        }
+
         public fun build(): KoogComposeContext<S> = KoogComposeContext(
             providerConfig          = providerConfig
                 ?: error("koog-compose: provider { } block is required."),
@@ -441,6 +465,7 @@ public data class KoogComposeContext<S>(
             stateStore              = stateStore,
             config                  = config,
             contextualInstructions  = contextualInstructions,
+            layoutEngineConfig      = layoutEngineConfig,
         )
     }
 
@@ -528,6 +553,7 @@ public class UnifiedAgentBuilder<S> {
     private var contextualInstructions: List<ContextualInstruction> = emptyList()
     private var store: SessionStore = InMemorySessionStore()
     private var sessionConfig: KoogSessionConfig = KoogSessionConfig()
+    private var layoutEngineConfig: LayoutEngineConfig? = null
 
     // Multi-agent fields
     private var mainAgentDefinition: KoogAgentDefinition? = null
@@ -572,6 +598,11 @@ public class UnifiedAgentBuilder<S> {
 
     public fun contextual(block: ContextualInstructionsBuilder.() -> Unit) {
         contextualInstructions = ContextualInstructionsBuilder().apply(block).build()
+    }
+
+    /** Enables the agent-driven layout engine. See [KoogComposeContext.Builder.layout]. */
+    public fun layout(block: LayoutEngineConfigBuilder.() -> Unit) {
+        layoutEngineConfig = LayoutEngineConfigBuilder().apply(block).build()
     }
 
     // ── Multi-agent DSL blocks ────────────────────────────────────────────
@@ -630,7 +661,36 @@ public class UnifiedAgentBuilder<S> {
                 stateStore = stateStore,
                 config = config,
                 contextualInstructions = contextualInstructions,
+                layoutEngineConfig = layoutEngineConfig,
             )
         }
     }
+}
+
+/**
+ * DSL builder for [LayoutEngineConfig].
+ *
+ * ```kotlin
+ * layout {
+ *     workflowContext   = WorkflowContext(...)
+ *     slotRegistry      = SlotRegistry(listOf(...))
+ *     componentRegistry = ComponentRegistry(listOf(...))
+ * }
+ * ```
+ */
+public class LayoutEngineConfigBuilder {
+    public var workflowContext: WorkflowContext? = null
+    public var slotRegistry: SlotRegistry? = null
+    public var componentRegistry: ComponentRegistry? = null
+    public var policy: LayoutPolicy = LayoutPolicyChain.Empty
+
+    public fun build(): LayoutEngineConfig = LayoutEngineConfig(
+        workflowContext   = workflowContext
+            ?: error("koog-compose layout { }: workflowContext is required"),
+        slotRegistry      = slotRegistry
+            ?: error("koog-compose layout { }: slotRegistry is required"),
+        componentRegistry = componentRegistry
+            ?: error("koog-compose layout { }: componentRegistry is required"),
+        policy            = policy,
+    )
 }

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/PhaseSession.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/PhaseSession.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.prompt.executor.model.PromptExecutor
 import io.github.koogcompose.event.EventHandlers
 import io.github.koogcompose.event.KoogEvent
+import io.github.koogcompose.layout.DefaultLayoutDirectiveProcessor
 import io.github.koogcompose.observability.AgentEvent
 import io.github.koogcompose.phase.PhaseAwareAgent
 import kotlinx.coroutines.CoroutineScope
@@ -55,6 +56,12 @@ public class PhaseSession<S>(
 
     // ── New — pull sink from config so callers don't need to pass it ──────
     private val eventSink = context.config.eventSink
+
+    /** Layout engine processor, non-null only when [KoogComposeContext.layoutEngineConfig] is set. */
+    public val layoutProcessor: DefaultLayoutDirectiveProcessor? =
+        context.layoutEngineConfig?.let { cfg ->
+            DefaultLayoutDirectiveProcessor(cfg, scope)
+        }
 
     // ── Activity state ─────────────────────────────────────────────────────
 
@@ -119,6 +126,9 @@ public class PhaseSession<S>(
                 _activity.value = AgentActivity.Idle
                 _activityDetail.value = ""
             }
+
+            // Signal layout engine that a new turn is starting so in-flight coalescing resets.
+            layoutProcessor?.beginTurn()
 
             _activity.value = AgentActivity.Thinking
             _activityDetail.value = ""

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/PhasesessionHandle.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/PhasesessionHandle.kt
@@ -1,6 +1,7 @@
 package io.github.koogcompose.session
 
 import ai.koog.prompt.executor.model.PromptExecutor
+import io.github.koogcompose.layout.DefaultLayoutDirectiveProcessor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -72,6 +73,10 @@ public class PhaseSessionHandle<S>(
 
     public val turnId: StateFlow<Int>
         get() = delegate.turnId
+
+    /** Non-null when the session was built with a `layout { }` block. */
+    public val layoutProcessor: DefaultLayoutDirectiveProcessor?
+        get() = delegate.layoutProcessor
 }
 
 /**

--- a/koog-compose-ui/src/commonMain/kotlin/io/github/koogcompose/ui/layout/LayoutHost.kt
+++ b/koog-compose-ui/src/commonMain/kotlin/io/github/koogcompose/ui/layout/LayoutHost.kt
@@ -1,0 +1,95 @@
+package io.github.koogcompose.ui.layout
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import io.github.koogcompose.layout.ComponentId
+import io.github.koogcompose.layout.ComponentProps
+import io.github.koogcompose.layout.DefaultLayoutDirectiveProcessor
+import io.github.koogcompose.layout.LayoutState
+import io.github.koogcompose.layout.LockMode
+import io.github.koogcompose.layout.SlotEntry
+import io.github.koogcompose.layout.SlotId
+
+/**
+ * Provides the composable content for a component given its [id] and current [props].
+ *
+ * Register one of these at startup in your ViewModel or DI graph and pass it down
+ * to every [LayoutSlotHost]. This keeps [koog-compose-core] free of Compose dependencies.
+ */
+public fun interface ComponentContentProvider {
+    @Composable
+    public fun Content(id: ComponentId, props: ComponentProps)
+}
+
+/**
+ * Renders the contents of [slotId] as reported by [processor].
+ *
+ * Each [SlotEntry] in the slot is passed to [contentProvider] in order.
+ * Components whose [SlotEntry.lockMode] is [LockMode.Hidden] are skipped entirely.
+ * Components with [LockMode.Disabled] or [LockMode.ReadOnly] are rendered — the
+ * host app's composable is responsible for applying the visual treatment (greyed-out,
+ * non-interactive) since koog-compose-ui has no knowledge of your design system.
+ *
+ * When [processor] is null (layout engine not configured) or the slot is empty,
+ * [emptyContent] is rendered instead. Defaults to rendering nothing.
+ *
+ * ### Example
+ * ```kotlin
+ * val provider = ComponentContentProvider { id, props ->
+ *     when (id.value) {
+ *         "promo_banner" -> PromoBanner(props)
+ *         "loyalty_card" -> LoyaltyCard(props)
+ *         else           -> Box(Modifier.fillMaxWidth().height(0.dp))
+ *     }
+ * }
+ *
+ * LayoutSlotHost(
+ *     slotId         = SlotId("hero"),
+ *     processor      = handle.layoutProcessor,
+ *     contentProvider = provider,
+ * )
+ * ```
+ */
+@Composable
+public fun LayoutSlotHost(
+    slotId: SlotId,
+    processor: DefaultLayoutDirectiveProcessor?,
+    contentProvider: ComponentContentProvider,
+    emptyContent: @Composable () -> Unit = {},
+) {
+    if (processor == null) {
+        emptyContent()
+        return
+    }
+
+    val layoutState by processor.layoutState.collectAsState()
+    LayoutSlotContent(
+        slotId = slotId,
+        layoutState = layoutState,
+        contentProvider = contentProvider,
+        emptyContent = emptyContent,
+    )
+}
+
+/**
+ * Stateless overload that accepts a pre-collected [LayoutState] snapshot.
+ * Useful when you want to hoist state collection out of this composable —
+ * e.g., to share it with sibling slots without extra subscriptions.
+ */
+@Composable
+public fun LayoutSlotContent(
+    slotId: SlotId,
+    layoutState: LayoutState,
+    contentProvider: ComponentContentProvider,
+    emptyContent: @Composable () -> Unit = {},
+) {
+    val entries = layoutState.entriesFor(slotId).filter { it.lockMode != LockMode.Hidden }
+    if (entries.isEmpty()) {
+        emptyContent()
+    } else {
+        for (entry in entries) {
+            contentProvider.Content(id = entry.componentId, props = entry.props)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Introduces a complete agent-driven layout engine that allows AI agents to propose UI layout mutations through a declarative directive system. The engine enforces schema validity, permissions, and slot constraints through a composable policy chain, then applies accepted directives to an immutable layout state.

## Key Changes

### Core Layout Engine
- **AgentLayoutDirective**: Five-directive sealed hierarchy (ShowComponent, HideComponent, ReorderComponents, SwapComponent, LockComponent) representing atomic layout mutations
- **LayoutState**: Immutable snapshot of component occupancy across slots with monotonic versioning
- **LayoutReducer**: Pure function reducer applying directives to state with slot capacity enforcement (Single/Multiple/Unbounded)
- **DirectiveOutcome**: Result types (Accepted, Rewritten, Rejected, Coalesced) published back to the agent for feedback

### Policy System
- **LayoutPolicy**: Interface for policy tiers to approve, rewrite, or deny directives
- **LayoutPolicyChain**: Chains multiple policies with short-circuit denial and rewrite propagation
- **SdkLayoutPolicy**: Built-in SDK tier enforcing schema validation, tag compatibility, permission checks, and lock-strengthening rules
- **DefaultLayoutDirectiveProcessor**: Single-threaded actor implementation processing directives in FIFO order with within-turn deduplication

### Slot & Component Registry
- **SlotRegistry/ComponentRegistry**: Immutable registries of available slots and components with cross-validation
- **LayoutSlot**: Declares slot capacity (Single/Multiple/Unbounded), allowed component tags, and default behavior
- **ComponentDefinition**: Metadata for components including tags and required permissions
- **ComponentProps**: String-keyed property bag for agent-to-component data passing

### Context & Configuration
- **WorkflowContext**: Session-scoped context (business ID, user role, workflow, device info)
- **UserRole**: Typed role abstraction with permission grants
- **LayoutEngineConfig**: Configuration bundle for processor initialization
- **LayoutEngineConfigBuilder**: DSL for declarative engine setup in KoogComposeContext

### UI Integration
- **LayoutSlotHost**: Composable that renders slot contents from processor state
- **LayoutSlotContent**: Stateless overload for hoisted state collection
- **ComponentContentProvider**: Interface for host apps to provide component composables

## Notable Implementation Details

- **Idempotent directives**: All directive types are replay-safe for fault tolerance
- **Position semantics**: Flexible insertion positioning (Start/End/Index/Before/After) with fallback behavior
- **LRU eviction**: Multiple-capacity slots automatically evict oldest entries when full
- **Lock strengthening**: Policy can only strengthen locks (Hidden > Disabled > ReadOnly), never weaken
- **Deduplication**: Within-turn duplicate correlation IDs are coalesced; cleared on turn boundaries
- **Compose-free core**: Engine layer has zero Compose dependencies, enabling pure unit testing
- **Permission-first**: Components checked against user role permissions before slot tag matching

## Integration Points
- **KoogComposeContext**: Extended with optional `layoutEngineConfig` and `layout()` DSL builder
- **PhaseSession**: Receives layout processor and calls `beginTurn()` at turn boundaries
- **PhaseSessionHandle**: Exposes layout processor to UI layer

https://claude.ai/code/session_01Nhfs1CTUg8HZHidxcwjdGc