### PR TITLE
Add Layer 1 layout engine: directives, policies, and workflow runtime

### DIFF
--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/AgentLayoutDirective.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/AgentLayoutDirective.kt
@@ -132,10 +132,11 @@ public sealed class DirectiveOutcome {
     public abstract val correlationId: DirectiveId
     public abstract val resultingStateVersion: Long?
 
-    /** Directive applied as-is. */
+    /** Directive applied as-is. [directiveReason] mirrors the original directive's reason field. */
     public data class Accepted(
         override val correlationId: DirectiveId,
         override val resultingStateVersion: Long,
+        public val directiveReason: String? = null,
     ) : DirectiveOutcome()
 
     /**

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/AgentLayoutDirective.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/AgentLayoutDirective.kt
@@ -1,0 +1,177 @@
+package io.github.koogcompose.layout
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.jvm.JvmInline
+
+/** Stable identifier for a single directive emission, used for tracing and correlation. */
+@JvmInline
+public value class DirectiveId(public val value: String) {
+    init { require(value.isNotBlank()) { "DirectiveId must not be blank" } }
+}
+
+/**
+ * Insertion position within a multi-component slot.
+ *
+ * - [Start] / [End]: relative to current contents.
+ * - [Index]: absolute zero-based index, clamped to slot size at reduction time.
+ * - [Before] / [After]: relative to a reference component; falls back to [End] if absent.
+ */
+public sealed class Position {
+    public data object Start : Position()
+    public data object End : Position()
+    public data class Index(public val index: Int) : Position() {
+        init { require(index >= 0) { "Position.Index must be non-negative" } }
+    }
+    public data class Before(public val reference: ComponentId) : Position()
+    public data class After(public val reference: ComponentId) : Position()
+}
+
+/** How a component is locked in place. Visible to the user, unlike permission denials. */
+public enum class LockMode { ReadOnly, Disabled, Hidden }
+
+/**
+ * Sealed hierarchy of mutations the agent can propose to the layout.
+ *
+ * Each subtype is a declarative DELTA asserting desired end-state, not an imperative
+ * command. The vocabulary is intentionally small (5 subtypes) for reliable emission
+ * from on-device models. All directives are idempotent at the reducer level — replay
+ * is safe.
+ *
+ * Every directive carries a [correlationId] so the agent can match its emissions to
+ * the [DirectiveOutcome]s it receives in the next turn.
+ */
+public sealed class AgentLayoutDirective {
+    public abstract val correlationId: DirectiveId
+    public abstract val issuedAt: Instant
+    public abstract val reason: String?
+
+    /**
+     * Asserts [componentId] should be visible in [slotId] at [position].
+     *
+     * Semantics: already in slot → reorder; in different slot → move; not shown → add.
+     */
+    public data class ShowComponent(
+        public val componentId: ComponentId,
+        public val slotId: SlotId,
+        public val position: Position = Position.End,
+        public val props: ComponentProps = ComponentProps.Empty,
+        override val correlationId: DirectiveId,
+        override val issuedAt: Instant = Clock.System.now(),
+        override val reason: String? = null,
+    ) : AgentLayoutDirective()
+
+    /**
+     * Asserts [componentId] should not be visible.
+     *
+     * If [slotId] is non-null, removes from that slot only. If null, removes from all slots.
+     */
+    public data class HideComponent(
+        public val componentId: ComponentId,
+        public val slotId: SlotId? = null,
+        override val correlationId: DirectiveId,
+        override val issuedAt: Instant = Clock.System.now(),
+        override val reason: String? = null,
+    ) : AgentLayoutDirective()
+
+    /**
+     * Asserts an explicit ordering for components within [slotId].
+     *
+     * Components in [orderedComponentIds] not currently in the slot are ignored (this
+     * directive does not add). Components currently in the slot but absent from
+     * [orderedComponentIds] keep their relative order, appended after the explicit set.
+     */
+    public data class ReorderComponents(
+        public val slotId: SlotId,
+        public val orderedComponentIds: List<ComponentId>,
+        override val correlationId: DirectiveId,
+        override val issuedAt: Instant = Clock.System.now(),
+        override val reason: String? = null,
+    ) : AgentLayoutDirective()
+
+    /**
+     * Atomically replaces [removeComponentId] with [insertComponentId] in [slotId].
+     *
+     * Rejected (not silently converted) if [removeComponentId] is not in the slot,
+     * because the agent's intent was specifically a swap.
+     */
+    public data class SwapComponent(
+        public val slotId: SlotId,
+        public val removeComponentId: ComponentId,
+        public val insertComponentId: ComponentId,
+        public val props: ComponentProps = ComponentProps.Empty,
+        override val correlationId: DirectiveId,
+        override val issuedAt: Instant = Clock.System.now(),
+        override val reason: String? = null,
+    ) : AgentLayoutDirective()
+
+    /**
+     * Applies [lockMode] to [componentId] in [slotId].
+     *
+     * Policy can strengthen a lock but never weaken it. Rejected if the component is
+     * not currently in the slot.
+     */
+    public data class LockComponent(
+        public val componentId: ComponentId,
+        public val slotId: SlotId,
+        public val lockMode: LockMode,
+        override val correlationId: DirectiveId,
+        override val issuedAt: Instant = Clock.System.now(),
+        override val reason: String? = null,
+    ) : AgentLayoutDirective()
+}
+
+/** Where in the system a state change originated. */
+public enum class DirectiveSource { Agent, Policy, UserAction, Default, Restore }
+
+/**
+ * Result of a directive's trip through the pipeline. Published to the outcomes flow
+ * the agent reads in subsequent turns. The Compose UI only consumes [LayoutState].
+ */
+public sealed class DirectiveOutcome {
+    public abstract val correlationId: DirectiveId
+    public abstract val resultingStateVersion: Long?
+
+    /** Directive applied as-is. */
+    public data class Accepted(
+        override val correlationId: DirectiveId,
+        override val resultingStateVersion: Long,
+    ) : DirectiveOutcome()
+
+    /**
+     * Directive was modified before application. Common rewrites: evict-then-show on
+     * Single slots; agent-issued ReadOnly lock upgraded by policy to Hidden.
+     */
+    public data class Rewritten(
+        override val correlationId: DirectiveId,
+        public val original: AgentLayoutDirective,
+        public val final: AgentLayoutDirective,
+        public val reason: String,
+        override val resultingStateVersion: Long,
+    ) : DirectiveOutcome()
+
+    /** Directive dropped entirely. State is unchanged. */
+    public data class Rejected(
+        override val correlationId: DirectiveId,
+        public val reason: String,
+        public val rejectedAt: PipelineStage,
+    ) : DirectiveOutcome() {
+        override val resultingStateVersion: Long? get() = null
+    }
+
+    /** Directive deduped against another in-flight directive in the coalescing window. */
+    public data class Coalesced(
+        override val correlationId: DirectiveId,
+        public val coalescedWith: DirectiveId,
+    ) : DirectiveOutcome() {
+        override val resultingStateVersion: Long? get() = null
+    }
+}
+
+/** Stage at which a directive was rejected. */
+public enum class PipelineStage {
+    SchemaValidation,
+    PolicyCheck,
+    SlotConstraintCheck,
+    Reduce,
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutDirectiveProcessor.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutDirectiveProcessor.kt
@@ -1,0 +1,172 @@
+package io.github.koogcompose.layout
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Processes [AgentLayoutDirective]s in FIFO order and publishes [DirectiveOutcome]s.
+ *
+ * Callers emit directives via [send] (fire-and-forget) and observe live layout
+ * state via [layoutState]. The agent reads back [outcomes] in subsequent turns
+ * to learn whether its directives were accepted, rewritten, rejected, or coalesced.
+ */
+public interface LayoutDirectiveProcessor {
+    /** Live, immediately consistent snapshot of the current layout. */
+    public val layoutState: StateFlow<LayoutState>
+
+    /** Hot stream of outcomes — one per processed directive. */
+    public val outcomes: SharedFlow<DirectiveOutcome>
+
+    /** Queue a directive for processing. Returns immediately (non-suspending). */
+    public fun send(directive: AgentLayoutDirective)
+
+    /**
+     * Signal the start of a new agent turn. Clears in-flight coalescing state so
+     * the same [DirectiveId] can be re-used across turns without being dropped.
+     *
+     * Called by [io.github.koogcompose.session.PhaseSession] at the top of every
+     * [io.github.koogcompose.session.PhaseSession.send] invocation.
+     */
+    public fun beginTurn()
+}
+
+/**
+ * Configuration bundle required to build a [DefaultLayoutDirectiveProcessor].
+ *
+ * Registered in [io.github.koogcompose.session.KoogComposeContext] at session
+ * initialization and passed into the processor when the session scope is ready.
+ */
+public data class LayoutEngineConfig(
+    val workflowContext: WorkflowContext,
+    val slotRegistry: SlotRegistry,
+    val componentRegistry: ComponentRegistry,
+    /** Host / workflow policy tiers applied after the built-in [SdkLayoutPolicy]. */
+    val policy: LayoutPolicy = LayoutPolicyChain.Empty,
+)
+
+/**
+ * Single-threaded actor implementation of [LayoutDirectiveProcessor].
+ *
+ * All mutations — both [send] directives and [beginTurn] signals — funnel through
+ * a single [Channel.UNLIMITED] channel consumed by one coroutine in [scope].
+ * This guarantees that [LayoutState] and the deduplication set are mutated
+ * sequentially without any external locks.
+ *
+ * Policy chain assembled at construction: [SdkLayoutPolicy] → host [LayoutEngineConfig.policy].
+ */
+public class DefaultLayoutDirectiveProcessor(
+    private val config: LayoutEngineConfig,
+    scope: CoroutineScope,
+    initialState: LayoutState = LayoutState.Empty,
+) : LayoutDirectiveProcessor {
+
+    // ── Actor message types ────────────────────────────────────────────────
+
+    private sealed interface ActorMessage
+    private data class Emit(val directive: AgentLayoutDirective) : ActorMessage
+    private data object BeginTurn : ActorMessage
+
+    // ── Policy ─────────────────────────────────────────────────────────────
+
+    private val sdkPolicy = SdkLayoutPolicy(config.slotRegistry, config.componentRegistry)
+    private val effectivePolicy: LayoutPolicy = LayoutPolicyChain(
+        buildList {
+            add(sdkPolicy)
+            if (config.policy != LayoutPolicyChain.Empty) add(config.policy)
+        }
+    )
+
+    // ── Observable state ───────────────────────────────────────────────────
+
+    private val _layoutState = MutableStateFlow(initialState)
+    override val layoutState: StateFlow<LayoutState> = _layoutState.asStateFlow()
+
+    private val _outcomes = MutableSharedFlow<DirectiveOutcome>(extraBufferCapacity = 64)
+    override val outcomes: SharedFlow<DirectiveOutcome> = _outcomes.asSharedFlow()
+
+    // ── Actor channel ──────────────────────────────────────────────────────
+
+    private val channel = Channel<ActorMessage>(Channel.UNLIMITED)
+
+    /** Correlation IDs seen in the current turn — reset by [BeginTurn] messages. */
+    private val inFlightIds = mutableSetOf<DirectiveId>()
+
+    init {
+        scope.launch {
+            for (message in channel) {
+                when (message) {
+                    is BeginTurn -> inFlightIds.clear()
+                    is Emit      -> processOne(message.directive)
+                }
+            }
+        }
+    }
+
+    override fun send(directive: AgentLayoutDirective) {
+        channel.trySend(Emit(directive))
+    }
+
+    override fun beginTurn() {
+        channel.trySend(BeginTurn)
+    }
+
+    private suspend fun processOne(directive: AgentLayoutDirective) {
+        // Within-turn deduplication: same correlationId → Coalesced outcome.
+        if (directive.correlationId in inFlightIds) {
+            _outcomes.emit(
+                DirectiveOutcome.Coalesced(
+                    correlationId = directive.correlationId,
+                    coalescedWith = directive.correlationId,
+                )
+            )
+            return
+        }
+        inFlightIds += directive.correlationId
+
+        val state = _layoutState.value
+        when (val decision = effectivePolicy.evaluate(directive, state, config.workflowContext)) {
+            is PolicyDecision.Allow -> {
+                val newState = LayoutReducer.apply(state, directive, config.slotRegistry)
+                _layoutState.value = newState
+                _outcomes.emit(
+                    DirectiveOutcome.Accepted(
+                        correlationId = directive.correlationId,
+                        resultingStateVersion = newState.version,
+                    )
+                )
+            }
+
+            is PolicyDecision.Rewrite -> {
+                val finalDirective = decision.replacement
+                val newState = LayoutReducer.apply(state, finalDirective, config.slotRegistry)
+                _layoutState.value = newState
+                _outcomes.emit(
+                    DirectiveOutcome.Rewritten(
+                        correlationId = directive.correlationId,
+                        original = directive,
+                        final = finalDirective,
+                        reason = decision.reason,
+                        resultingStateVersion = newState.version,
+                    )
+                )
+            }
+
+            is PolicyDecision.Deny -> {
+                _outcomes.emit(
+                    DirectiveOutcome.Rejected(
+                        correlationId = directive.correlationId,
+                        reason = decision.reason,
+                        rejectedAt = decision.stage,
+                    )
+                )
+            }
+        }
+    }
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutDirectiveProcessor.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutDirectiveProcessor.kt
@@ -139,6 +139,7 @@ public class DefaultLayoutDirectiveProcessor(
                     DirectiveOutcome.Accepted(
                         correlationId = directive.correlationId,
                         resultingStateVersion = newState.version,
+                        directiveReason = directive.reason,
                     )
                 )
             }

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutPolicy.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutPolicy.kt
@@ -1,0 +1,234 @@
+package io.github.koogcompose.layout
+
+/**
+ * A single policy tier that can approve, rewrite, or reject a layout directive.
+ *
+ * Three tiers are assembled in priority order:
+ *   SDK ([SdkLayoutPolicy]) → Host (registered at startup) → Workflow (optional per-workflow).
+ * All tiers are chained via [LayoutPolicyChain].
+ */
+public interface LayoutPolicy {
+    /**
+     * Evaluate [directive] against the current [state] and [context].
+     *
+     * Return [PolicyDecision.Allow] to pass the directive unchanged, [PolicyDecision.Rewrite]
+     * to substitute a modified directive, or [PolicyDecision.Deny] to reject it entirely.
+     */
+    public fun evaluate(
+        directive: AgentLayoutDirective,
+        state: LayoutState,
+        context: WorkflowContext,
+    ): PolicyDecision
+}
+
+/** The outcome of a single policy tier's evaluation. */
+public sealed class PolicyDecision {
+    public data object Allow : PolicyDecision()
+
+    public data class Rewrite(
+        val replacement: AgentLayoutDirective,
+        val reason: String,
+    ) : PolicyDecision()
+
+    public data class Deny(
+        val reason: String,
+        val stage: PipelineStage = PipelineStage.PolicyCheck,
+    ) : PolicyDecision()
+}
+
+/**
+ * Chains multiple [LayoutPolicy] instances in order. First Deny short-circuits.
+ * First Rewrite is applied and subsequent policies evaluate the rewritten directive.
+ */
+public class LayoutPolicyChain(
+    internal val policies: List<LayoutPolicy>,
+) : LayoutPolicy {
+
+    override fun evaluate(
+        directive: AgentLayoutDirective,
+        state: LayoutState,
+        context: WorkflowContext,
+    ): PolicyDecision {
+        var current: AgentLayoutDirective = directive
+        var rewritten = false
+        var rewriteReason = ""
+
+        for (policy in policies) {
+            when (val decision = policy.evaluate(current, state, context)) {
+                is PolicyDecision.Allow  -> continue
+                is PolicyDecision.Deny   -> return decision
+                is PolicyDecision.Rewrite -> {
+                    current = decision.replacement
+                    rewritten = true
+                    rewriteReason = decision.reason
+                }
+            }
+        }
+
+        return if (rewritten) PolicyDecision.Rewrite(current, rewriteReason)
+        else PolicyDecision.Allow
+    }
+
+    public companion object {
+        public val Empty: LayoutPolicyChain = LayoutPolicyChain(emptyList())
+    }
+}
+
+/**
+ * SDK-tier built-in policy. Enforces schema validity, tag compatibility,
+ * permission requirements, and lock-strengthening rules.
+ *
+ * This is always the first policy in the chain assembled by
+ * [DefaultLayoutDirectiveProcessor] — host and workflow policies run after.
+ */
+public class SdkLayoutPolicy(
+    private val slotRegistry: SlotRegistry,
+    private val componentRegistry: ComponentRegistry,
+) : LayoutPolicy {
+
+    override fun evaluate(
+        directive: AgentLayoutDirective,
+        state: LayoutState,
+        context: WorkflowContext,
+    ): PolicyDecision = when (directive) {
+        is AgentLayoutDirective.ShowComponent     -> validateShow(directive, context)
+        is AgentLayoutDirective.HideComponent     -> validateHide(directive)
+        is AgentLayoutDirective.ReorderComponents -> validateSlot(directive.slotId)
+        is AgentLayoutDirective.SwapComponent     -> validateSwap(directive, state, context)
+        is AgentLayoutDirective.LockComponent     -> validateLock(directive, state)
+    }
+
+    private fun validateShow(
+        d: AgentLayoutDirective.ShowComponent,
+        ctx: WorkflowContext,
+    ): PolicyDecision {
+        val slot = slotRegistry[d.slotId]
+            ?: return PolicyDecision.Deny(
+                "Unknown slot '${d.slotId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        val component = componentRegistry[d.componentId]
+            ?: return PolicyDecision.Deny(
+                "Unknown component '${d.componentId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        if (component.tags.none { it in slot.allowedComponentTags }) {
+            return PolicyDecision.Deny(
+                "Component '${d.componentId.value}' has no tag matching slot '${d.slotId.value}'",
+                PipelineStage.SlotConstraintCheck,
+            )
+        }
+        if (!ctx.userRole.permissions.containsAll(component.requiredPermissions)) {
+            return PolicyDecision.Deny(
+                "Insufficient permissions to show '${d.componentId.value}'",
+                PipelineStage.PolicyCheck,
+            )
+        }
+        return PolicyDecision.Allow
+    }
+
+    private fun validateHide(d: AgentLayoutDirective.HideComponent): PolicyDecision {
+        if (d.slotId != null && !slotRegistry.contains(d.slotId)) {
+            return PolicyDecision.Deny(
+                "Unknown slot '${d.slotId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        if (!componentRegistry.contains(d.componentId)) {
+            return PolicyDecision.Deny(
+                "Unknown component '${d.componentId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        return PolicyDecision.Allow
+    }
+
+    private fun validateSlot(slotId: SlotId): PolicyDecision {
+        if (!slotRegistry.contains(slotId)) {
+            return PolicyDecision.Deny(
+                "Unknown slot '${slotId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        return PolicyDecision.Allow
+    }
+
+    private fun validateSwap(
+        d: AgentLayoutDirective.SwapComponent,
+        state: LayoutState,
+        ctx: WorkflowContext,
+    ): PolicyDecision {
+        val slot = slotRegistry[d.slotId]
+            ?: return PolicyDecision.Deny(
+                "Unknown slot '${d.slotId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        val insertComponent = componentRegistry[d.insertComponentId]
+            ?: return PolicyDecision.Deny(
+                "Unknown component '${d.insertComponentId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        if (!componentRegistry.contains(d.removeComponentId)) {
+            return PolicyDecision.Deny(
+                "Unknown component '${d.removeComponentId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        if (state.entriesFor(d.slotId).none { it.componentId == d.removeComponentId }) {
+            return PolicyDecision.Deny(
+                "Component '${d.removeComponentId.value}' is not in slot '${d.slotId.value}'",
+                PipelineStage.Reduce,
+            )
+        }
+        if (insertComponent.tags.none { it in slot.allowedComponentTags }) {
+            return PolicyDecision.Deny(
+                "Component '${d.insertComponentId.value}' has no tag matching slot '${d.slotId.value}'",
+                PipelineStage.SlotConstraintCheck,
+            )
+        }
+        if (!ctx.userRole.permissions.containsAll(insertComponent.requiredPermissions)) {
+            return PolicyDecision.Deny(
+                "Insufficient permissions to show '${d.insertComponentId.value}'",
+                PipelineStage.PolicyCheck,
+            )
+        }
+        return PolicyDecision.Allow
+    }
+
+    private fun validateLock(
+        d: AgentLayoutDirective.LockComponent,
+        state: LayoutState,
+    ): PolicyDecision {
+        if (!slotRegistry.contains(d.slotId)) {
+            return PolicyDecision.Deny(
+                "Unknown slot '${d.slotId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        if (!componentRegistry.contains(d.componentId)) {
+            return PolicyDecision.Deny(
+                "Unknown component '${d.componentId.value}'",
+                PipelineStage.SchemaValidation,
+            )
+        }
+        val entry = state.entriesFor(d.slotId).find { it.componentId == d.componentId }
+            ?: return PolicyDecision.Deny(
+                "Component '${d.componentId.value}' is not in slot '${d.slotId.value}'",
+                PipelineStage.Reduce,
+            )
+        val existing = entry.lockMode
+        if (existing != null && !d.lockMode.isStrongerOrEqualTo(existing)) {
+            return PolicyDecision.Deny(
+                "Cannot weaken lock from $existing to ${d.lockMode} — policy can only strengthen locks",
+                PipelineStage.PolicyCheck,
+            )
+        }
+        return PolicyDecision.Allow
+    }
+}
+
+private fun LockMode.isStrongerOrEqualTo(other: LockMode): Boolean = when (this) {
+    LockMode.ReadOnly -> other == LockMode.ReadOnly
+    LockMode.Disabled -> other == LockMode.ReadOnly || other == LockMode.Disabled
+    LockMode.Hidden   -> true
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutReducer.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutReducer.kt
@@ -1,0 +1,166 @@
+package io.github.koogcompose.layout
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * Pure function: applies [directive] to [state] and returns the new [LayoutState].
+ *
+ * No coroutines, no Compose — designed to be fully unit-testable in isolation.
+ * [slotRegistry] is optional; when provided, [SlotCapacity] constraints are
+ * enforced (Single → replace existing; Multiple(max) → LRU eviction). When
+ * null (useful in tests), capacity is treated as [SlotCapacity.Unbounded].
+ *
+ * Called by [DefaultLayoutDirectiveProcessor] only after all policies pass.
+ * Replay is safe — all subtypes are idempotent.
+ */
+public object LayoutReducer {
+
+    public fun apply(
+        state: LayoutState,
+        directive: AgentLayoutDirective,
+        slotRegistry: SlotRegistry? = null,
+        now: Instant = Clock.System.now(),
+    ): LayoutState = when (directive) {
+        is AgentLayoutDirective.ShowComponent     -> applyShow(state, directive, slotRegistry, now)
+        is AgentLayoutDirective.HideComponent     -> applyHide(state, directive)
+        is AgentLayoutDirective.ReorderComponents -> applyReorder(state, directive)
+        is AgentLayoutDirective.SwapComponent     -> applySwap(state, directive, now)
+        is AgentLayoutDirective.LockComponent     -> applyLock(state, directive)
+    }
+
+    // ── ShowComponent ──────────────────────────────────────────────────────
+
+    private fun applyShow(
+        state: LayoutState,
+        d: AgentLayoutDirective.ShowComponent,
+        slotRegistry: SlotRegistry?,
+        now: Instant,
+    ): LayoutState {
+        val existing = state.slots[d.slotId] ?: emptyList()
+
+        // Reuse the existing entry (preserving addedAt) if the component is already present.
+        val entry = existing.firstOrNull { it.componentId == d.componentId }
+            ?.copy(props = d.props)
+            ?: SlotEntry(componentId = d.componentId, props = d.props, addedAt = now)
+
+        // Remove the target component before re-inserting it at the new position.
+        val withoutTarget = existing.filter { it.componentId != d.componentId }
+
+        // Apply slot-capacity constraints.
+        val capacity = slotRegistry?.get(d.slotId)?.capacity
+        val cappedBase: List<SlotEntry> = when (capacity) {
+            is SlotCapacity.Single    -> emptyList()  // evict any existing occupant
+            is SlotCapacity.Multiple  -> {
+                if (withoutTarget.size >= capacity.max) {
+                    // LRU eviction: the list is insertion-ordered; oldest is first.
+                    withoutTarget.drop(1)
+                } else {
+                    withoutTarget
+                }
+            }
+            is SlotCapacity.Unbounded, null -> withoutTarget
+        }
+
+        val inserted = insertAt(cappedBase, d.position, entry)
+        return state.copy(
+            slots = state.slots + (d.slotId to inserted),
+            version = state.version + 1,
+        )
+    }
+
+    // ── HideComponent ──────────────────────────────────────────────────────
+
+    private fun applyHide(
+        state: LayoutState,
+        d: AgentLayoutDirective.HideComponent,
+    ): LayoutState {
+        val targetSlots: List<SlotId> = if (d.slotId != null) {
+            listOf(d.slotId)
+        } else {
+            state.slots.keys.toList()
+        }
+        var newSlots = state.slots
+        for (slotId in targetSlots) {
+            newSlots = newSlots + (slotId to (newSlots[slotId] ?: emptyList())
+                .filter { it.componentId != d.componentId })
+        }
+        return state.copy(slots = newSlots, version = state.version + 1)
+    }
+
+    // ── ReorderComponents ──────────────────────────────────────────────────
+
+    private fun applyReorder(
+        state: LayoutState,
+        d: AgentLayoutDirective.ReorderComponents,
+    ): LayoutState {
+        val existing = state.slots[d.slotId] ?: return state
+        val byId = existing.associateBy { it.componentId }
+        val orderedSet = d.orderedComponentIds.toSet()
+        val explicit = d.orderedComponentIds.mapNotNull { byId[it] }
+        val rest = existing.filter { it.componentId !in orderedSet }
+        return state.copy(
+            slots = state.slots + (d.slotId to explicit + rest),
+            version = state.version + 1,
+        )
+    }
+
+    // ── SwapComponent ──────────────────────────────────────────────────────
+
+    private fun applySwap(
+        state: LayoutState,
+        d: AgentLayoutDirective.SwapComponent,
+        now: Instant,
+    ): LayoutState {
+        val existing = state.slots[d.slotId] ?: return state
+        val newEntry = SlotEntry(componentId = d.insertComponentId, props = d.props, addedAt = now)
+        val replaced = existing.map { entry ->
+            if (entry.componentId == d.removeComponentId) newEntry else entry
+        }
+        return state.copy(
+            slots = state.slots + (d.slotId to replaced),
+            version = state.version + 1,
+        )
+    }
+
+    // ── LockComponent ──────────────────────────────────────────────────────
+
+    private fun applyLock(
+        state: LayoutState,
+        d: AgentLayoutDirective.LockComponent,
+    ): LayoutState {
+        val existing = state.slots[d.slotId] ?: return state
+        val updated = existing.map { entry ->
+            if (entry.componentId == d.componentId) entry.copy(lockMode = d.lockMode) else entry
+        }
+        return state.copy(
+            slots = state.slots + (d.slotId to updated),
+            version = state.version + 1,
+        )
+    }
+
+    // ── Position helpers ───────────────────────────────────────────────────
+
+    private fun insertAt(
+        base: List<SlotEntry>,
+        position: Position,
+        entry: SlotEntry,
+    ): List<SlotEntry> = when (position) {
+        is Position.Start -> listOf(entry) + base
+        is Position.End   -> base + entry
+        is Position.Index -> {
+            val clamped = position.index.coerceIn(0, base.size)
+            base.toMutableList().apply { add(clamped, entry) }
+        }
+        is Position.Before -> {
+            val idx = base.indexOfFirst { it.componentId == position.reference }
+            if (idx < 0) base + entry
+            else base.toMutableList().apply { add(idx, entry) }
+        }
+        is Position.After -> {
+            val idx = base.indexOfFirst { it.componentId == position.reference }
+            if (idx < 0) base + entry
+            else base.toMutableList().apply { add(idx + 1, entry) }
+        }
+    }
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutSlot.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutSlot.kt
@@ -1,0 +1,169 @@
+package io.github.koogcompose.layout
+
+import kotlin.jvm.JvmInline
+
+/** Stable identifier for a slot — an addressing location the agent targets. */
+@JvmInline
+public value class SlotId(public val value: String) {
+    init { require(value.isNotBlank()) { "SlotId must not be blank" } }
+}
+
+/** Stable identifier for a component — the things that flow through slots. */
+@JvmInline
+public value class ComponentId(public val value: String) {
+    init { require(value.isNotBlank()) { "ComponentId must not be blank" } }
+}
+
+/**
+ * Semantic tag attached to both slots and components. A slot declares which tags it
+ * accepts; only components with at least one matching tag can be placed in it.
+ */
+@JvmInline
+public value class Tag(public val value: String) {
+    init { require(value.isNotBlank()) { "Tag must not be blank" } }
+}
+
+/**
+ * Declares a layout slot. Created by the host app and registered in [SlotRegistry] at
+ * startup. Slots are immutable — adding a new slot requires a new app version.
+ */
+public data class LayoutSlot(
+    public val id: SlotId,
+    public val capacity: SlotCapacity,
+    public val allowedComponentTags: Set<Tag>,
+    public val defaultBehavior: SlotDefault = SlotDefault.Empty,
+) {
+    init {
+        require(allowedComponentTags.isNotEmpty()) {
+            "LayoutSlot ${id.value} must declare at least one allowed tag"
+        }
+    }
+}
+
+/**
+ * How many components a slot can hold simultaneously.
+ *
+ * - [Single]: exactly one; Show into a full slot evicts the existing component.
+ * - [Multiple]: up to [Multiple.max]; Show into a full slot causes LRU eviction.
+ * - [Unbounded]: no cap.
+ */
+public sealed class SlotCapacity {
+    public data object Single : SlotCapacity()
+    public data class Multiple(public val max: Int) : SlotCapacity() {
+        init { require(max >= 2) { "Multiple capacity max must be >= 2; use Single for one" } }
+    }
+    public data object Unbounded : SlotCapacity()
+}
+
+/**
+ * What a slot displays when empty.
+ *
+ * - [Empty]: render nothing.
+ * - [Placeholder]: render the host-provided placeholder composable.
+ * - [FallbackComponent]: render the named component with empty props. Must reference a
+ *   registered component or validation will fail at startup.
+ */
+public sealed class SlotDefault {
+    public data object Empty : SlotDefault()
+    public data object Placeholder : SlotDefault()
+    public data class FallbackComponent(public val componentId: ComponentId) : SlotDefault()
+}
+
+/**
+ * Free-form, immutable bag of properties passed from the agent directive into the
+ * rendered component. Kept as a string map so the serialization boundary is simple
+ * (agent emits JSON strings, component reads what it needs).
+ */
+public data class ComponentProps(
+    public val values: Map<String, String> = emptyMap(),
+) {
+    public companion object {
+        public val Empty: ComponentProps = ComponentProps()
+    }
+
+    public fun get(key: String): String? = values[key]
+    public fun getOrDefault(key: String, default: String): String = values[key] ?: default
+}
+
+/**
+ * Host-app-declared registry of every slot the app supports.
+ * Built at startup, immutable thereafter.
+ */
+public class SlotRegistry(slots: Iterable<LayoutSlot>) {
+    private val slotList = slots.toList()
+    private val bySlotId: Map<SlotId, LayoutSlot> = slotList.associateBy { it.id }.also { map ->
+        require(map.size == slotList.size) { "SlotRegistry contains duplicate SlotIds" }
+    }
+
+    public val all: Collection<LayoutSlot> get() = bySlotId.values
+    public operator fun get(id: SlotId): LayoutSlot? = bySlotId[id]
+    public fun contains(id: SlotId): Boolean = id in bySlotId
+    public fun require(id: SlotId): LayoutSlot =
+        bySlotId[id] ?: throw IllegalArgumentException("Unknown SlotId: ${id.value}")
+}
+
+/**
+ * Host-app-declared registry of every component the agent can reference.
+ * Built at startup, immutable thereafter.
+ *
+ * @param requiredPermissions components are only shown to roles whose
+ *   [UserRole.permissions] is a superset of this set — the first line of defense.
+ */
+public class ComponentRegistry(components: Iterable<ComponentDefinition>) {
+    private val componentList = components.toList()
+    private val byId: Map<ComponentId, ComponentDefinition> =
+        componentList.associateBy { it.id }.also { map ->
+            require(map.size == componentList.size) {
+                "ComponentRegistry contains duplicate ComponentIds"
+            }
+        }
+
+    public val all: Collection<ComponentDefinition> get() = byId.values
+    public operator fun get(id: ComponentId): ComponentDefinition? = byId[id]
+    public fun contains(id: ComponentId): Boolean = id in byId
+    public fun require(id: ComponentId): ComponentDefinition =
+        byId[id] ?: throw IllegalArgumentException("Unknown ComponentId: ${id.value}")
+
+    /**
+     * Cross-validates this registry against a [SlotRegistry]: every
+     * [SlotDefault.FallbackComponent] must reference a registered component whose tags
+     * intersect the slot's [LayoutSlot.allowedComponentTags].
+     *
+     * Call once at startup after both registries are built. Throws on the first violation.
+     */
+    public fun validateAgainst(slotRegistry: SlotRegistry) {
+        slotRegistry.all.forEach { slot ->
+            val default = slot.defaultBehavior
+            if (default is SlotDefault.FallbackComponent) {
+                val component = byId[default.componentId]
+                    ?: error(
+                        "Slot '${slot.id.value}' declares fallback component " +
+                            "'${default.componentId.value}' which is not registered."
+                    )
+                require(component.tags.any { it in slot.allowedComponentTags }) {
+                    "Fallback component '${component.id.value}' for slot '${slot.id.value}' " +
+                        "has no tag matching the slot's allowed tags."
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Metadata for a component the agent can place. The [content] composable is resolved
+ * by [io.github.koogcompose.layout.ui.LayoutHost] at render time via a
+ * [ComponentContentProvider] registered in the UI layer.
+ *
+ * Keeping component metadata separate from the composable lambda lets the engine files
+ * remain Compose-free and fully unit-testable.
+ */
+public data class ComponentDefinition(
+    public val id: ComponentId,
+    public val tags: Set<Tag>,
+    public val requiredPermissions: Set<Permission> = emptySet(),
+) {
+    init { require(tags.isNotEmpty()) { "ComponentDefinition ${id.value} must declare at least one tag" } }
+
+    override fun equals(other: Any?): Boolean = other is ComponentDefinition && other.id == id
+    override fun hashCode(): Int = id.hashCode()
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutState.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutState.kt
@@ -1,0 +1,40 @@
+package io.github.koogcompose.layout
+
+import kotlinx.datetime.Instant
+
+/**
+ * Immutable snapshot of a single component's occupancy in a slot.
+ *
+ * [addedAt] records when the component was placed; used for LRU eviction in
+ * [SlotCapacity.Multiple] slots. [lockMode] is non-null only once a
+ * [AgentLayoutDirective.LockComponent] has been applied.
+ */
+public data class SlotEntry(
+    val componentId: ComponentId,
+    val props: ComponentProps,
+    val lockMode: LockMode? = null,
+    val addedAt: Instant,
+)
+
+/**
+ * Immutable snapshot of the entire agent-driven layout.
+ *
+ * Each value in [slots] is the ordered list of [SlotEntry] items currently
+ * occupying that slot. Slots not yet touched by any directive are absent from
+ * the map (check [entriesFor] for a safe accessor).
+ *
+ * [version] is a monotonically-increasing counter that increments on every
+ * successful directive application. The Compose UI can use it as a cheap
+ * change signal without deep structural comparison.
+ */
+public data class LayoutState(
+    val slots: Map<SlotId, List<SlotEntry>> = emptyMap(),
+    val version: Long = 0L,
+) {
+    public fun entriesFor(slotId: SlotId): List<SlotEntry> = slots[slotId] ?: emptyList()
+    public fun isEmpty(): Boolean = slots.all { it.value.isEmpty() }
+
+    public companion object {
+        public val Empty: LayoutState = LayoutState()
+    }
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/WorkflowContext.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/WorkflowContext.kt
@@ -1,0 +1,87 @@
+package io.github.koogcompose.layout
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Immutable, session-scoped context describing WHO is using the app and WHAT workflow
+ * they are running. Passed to [io.github.koogcompose.session.KoogComposeContext] at
+ * session initialization and never mutated for the lifetime of the session.
+ *
+ * The combination of [businessId] + [activeWorkflow] is what the cloud config layer
+ * (Layer 3) uses to look up the appropriate WorkflowDefinition.
+ */
+public data class WorkflowContext(
+    public val businessId: BusinessId,
+    public val userRole: UserRole,
+    public val activeWorkflow: WorkflowId,
+    public val deviceContext: DeviceContext,
+    public val sessionMetadata: Map<String, String> = emptyMap(),
+)
+
+@JvmInline
+public value class BusinessId(public val value: String) {
+    init { require(value.isNotBlank()) { "BusinessId must not be blank" } }
+}
+
+@JvmInline
+public value class WorkflowId(public val value: String) {
+    init { require(value.isNotBlank()) { "WorkflowId must not be blank" } }
+}
+
+/**
+ * Typed user role. Host apps subclass this once at startup and register every role
+ * they support. The [permissions] set is the authoritative grant consulted by the
+ * policy layer on every directive.
+ *
+ * Roles do not change mid-session. If a user's role changes, the host app starts a
+ * new session with a new [WorkflowContext].
+ */
+public abstract class UserRole(
+    public val id: String,
+    public val displayName: String,
+    public val permissions: Set<Permission>,
+) {
+    init { require(id.isNotBlank()) { "UserRole.id must not be blank" } }
+
+    final override fun equals(other: Any?): Boolean = other is UserRole && other.id == id
+    final override fun hashCode(): Int = id.hashCode()
+    final override fun toString(): String = "UserRole($id)"
+}
+
+/**
+ * A capability grant. Components carry [ComponentSpec.requiredPermissions] which the
+ * policy layer compares against [UserRole.permissions].
+ */
+@JvmInline
+public value class Permission(public val name: String) {
+    init { require(name.isNotBlank()) { "Permission.name must not be blank" } }
+}
+
+/** Conventional permissions the SDK uses for its own engine-level checks. */
+public object Permissions {
+    public val Read: Permission = Permission("koog.read")
+    public val Write: Permission = Permission("koog.write")
+    public val Admin: Permission = Permission("koog.admin")
+}
+
+/**
+ * Snapshot of the device the session is running on. Used by the agent to reason about
+ * what UI is appropriate (denser layouts on tablets, simpler layouts when offline, etc.).
+ */
+public data class DeviceContext(
+    public val platform: Platform,
+    public val formFactor: FormFactor,
+    public val networkClass: NetworkClass,
+    public val locale: String,
+)
+
+public enum class Platform { Android, IOS, Desktop, Web }
+
+public enum class FormFactor { Phone, Tablet, Desktop }
+
+/**
+ * Coarse-grained network classification. Important for markets where degraded/offline
+ * operation is common — the agent reads this to decide whether to attempt cloud-bound
+ * directives or stay strictly on-device.
+ */
+public enum class NetworkClass { Online, Degraded, Offline }

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/WorkflowPolicy.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/WorkflowPolicy.kt
@@ -1,0 +1,68 @@
+package io.github.koogcompose.layout
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * A predicate that must hold after every successful directive application. Functions
+ * cannot be serialized to JSON, so invariants are a code-only concept — OTA workflows
+ * silently receive no invariants.
+ */
+public fun interface LayoutInvariant {
+    public fun check(state: LayoutState): Boolean
+}
+
+/**
+ * Coarse access restriction for an entire slot, used by workflow-tier policy to
+ * narrow what was granted at the host tier. Policy can only restrict, never widen.
+ */
+public enum class SlotAccess {
+    /** Slot is visible and interactive. Default when no override is set. */
+    Normal,
+    /** Slot is visible but not interactive (same semantics as [LockMode.ReadOnly]). */
+    ReadOnly,
+    /** Slot contents are shown but greyed out (same as [LockMode.Disabled]). */
+    Disabled,
+    /** Slot is completely invisible to this role (same as [LockMode.Hidden]). */
+    Hidden,
+}
+
+/**
+ * Per-session rate limit for agent-emitted directives.
+ *
+ * [perTurn] caps how many directives a single agent turn may emit. [perSession]
+ * caps the total across the session lifetime. [coalescingWindow] is the window
+ * within which duplicate [DirectiveId]s are deduplicated.
+ */
+public data class RateLimit(
+    val perTurn: Int = 20,
+    val perSession: Int = 500,
+    val coalescingWindow: Duration = 16.milliseconds,
+) {
+    init {
+        require(perTurn > 0) { "RateLimit.perTurn must be positive" }
+        require(perSession > 0) { "RateLimit.perSession must be positive" }
+    }
+
+    public companion object {
+        public val Default: RateLimit = RateLimit()
+    }
+}
+
+/**
+ * Workflow-tier policy snapshot. Built by [io.github.koogcompose.workflow.WorkflowPolicyBuilder]
+ * and consumed by the policy chain. Can only narrow what host policy granted.
+ *
+ * [invariants] are omitted when the workflow is loaded from JSON — they are
+ * code-only constructs that cannot be expressed in a wire format.
+ */
+public data class WorkflowPolicy(
+    val slotAccessOverrides: Map<UserRole, Map<SlotId, SlotAccess>> = emptyMap(),
+    val componentRoleOverrides: Map<ComponentId, Set<UserRole>> = emptyMap(),
+    val invariants: List<LayoutInvariant> = emptyList(),
+    val rateLimit: RateLimit = RateLimit.Default,
+) {
+    public companion object {
+        public val Empty: WorkflowPolicy = WorkflowPolicy()
+    }
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/KoogComposeContext.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/KoogComposeContext.kt
@@ -1,6 +1,12 @@
 package io.github.koogcompose.session
 
 import io.github.koogcompose.event.EventHandlers
+import io.github.koogcompose.layout.LayoutEngineConfig
+import io.github.koogcompose.layout.LayoutPolicy
+import io.github.koogcompose.layout.LayoutPolicyChain
+import io.github.koogcompose.layout.SlotRegistry
+import io.github.koogcompose.layout.ComponentRegistry
+import io.github.koogcompose.layout.WorkflowContext
 import io.github.koogcompose.observability.EventSink
 import io.github.koogcompose.observability.NoOpEventSink
 import io.github.koogcompose.phase.Phase
@@ -292,6 +298,7 @@ public data class KoogComposeContext<S>(
     override val stateStore: KoogStateStore<S>?,
     val config: KoogConfig,
     val contextualInstructions: List<ContextualInstruction> = emptyList(),
+    val layoutEngineConfig: LayoutEngineConfig? = null,
 ) : KoogDefinition<S> {
     public fun createProvider(): AIProvider =
         ProviderRuntimeRegistry.create(this) ?: KoogAIProvider(this)
@@ -379,6 +386,7 @@ public data class KoogComposeContext<S>(
         private var eventHandlers: EventHandlers = EventHandlers.Empty
         private var config: KoogConfig = KoogConfig()
         private var contextualInstructions: List<ContextualInstruction> = emptyList()
+        private var layoutEngineConfig: LayoutEngineConfig? = null
 
         public fun provider(block: ProviderConfigBuilder.() -> Unit) {
             providerConfig = ProviderConfigBuilder().apply(block).build()
@@ -430,6 +438,22 @@ public data class KoogComposeContext<S>(
             contextualInstructions = ContextualInstructionsBuilder().apply(block).build()
         }
 
+        /**
+         * Enables the agent-driven layout engine for this session.
+         *
+         * ```kotlin
+         * layout {
+         *     workflowContext = WorkflowContext(...)
+         *     slotRegistry    = SlotRegistry(listOf(...))
+         *     componentRegistry = ComponentRegistry(listOf(...))
+         *     policy { /* optional host/workflow policy tiers */ }
+         * }
+         * ```
+         */
+        public fun layout(block: LayoutEngineConfigBuilder.() -> Unit) {
+            layoutEngineConfig = LayoutEngineConfigBuilder().apply(block).build()
+        }
+
         public fun build(): KoogComposeContext<S> = KoogComposeContext(
             providerConfig          = providerConfig
                 ?: error("koog-compose: provider { } block is required."),
@@ -441,6 +465,7 @@ public data class KoogComposeContext<S>(
             stateStore              = stateStore,
             config                  = config,
             contextualInstructions  = contextualInstructions,
+            layoutEngineConfig      = layoutEngineConfig,
         )
     }
 
@@ -528,6 +553,7 @@ public class UnifiedAgentBuilder<S> {
     private var contextualInstructions: List<ContextualInstruction> = emptyList()
     private var store: SessionStore = InMemorySessionStore()
     private var sessionConfig: KoogSessionConfig = KoogSessionConfig()
+    private var layoutEngineConfig: LayoutEngineConfig? = null
 
     // Multi-agent fields
     private var mainAgentDefinition: KoogAgentDefinition? = null
@@ -572,6 +598,11 @@ public class UnifiedAgentBuilder<S> {
 
     public fun contextual(block: ContextualInstructionsBuilder.() -> Unit) {
         contextualInstructions = ContextualInstructionsBuilder().apply(block).build()
+    }
+
+    /** Enables the agent-driven layout engine. See [KoogComposeContext.Builder.layout]. */
+    public fun layout(block: LayoutEngineConfigBuilder.() -> Unit) {
+        layoutEngineConfig = LayoutEngineConfigBuilder().apply(block).build()
     }
 
     // ── Multi-agent DSL blocks ────────────────────────────────────────────
@@ -630,7 +661,36 @@ public class UnifiedAgentBuilder<S> {
                 stateStore = stateStore,
                 config = config,
                 contextualInstructions = contextualInstructions,
+                layoutEngineConfig = layoutEngineConfig,
             )
         }
     }
+}
+
+/**
+ * DSL builder for [LayoutEngineConfig].
+ *
+ * ```kotlin
+ * layout {
+ *     workflowContext   = WorkflowContext(...)
+ *     slotRegistry      = SlotRegistry(listOf(...))
+ *     componentRegistry = ComponentRegistry(listOf(...))
+ * }
+ * ```
+ */
+public class LayoutEngineConfigBuilder {
+    public var workflowContext: WorkflowContext? = null
+    public var slotRegistry: SlotRegistry? = null
+    public var componentRegistry: ComponentRegistry? = null
+    public var policy: LayoutPolicy = LayoutPolicyChain.Empty
+
+    public fun build(): LayoutEngineConfig = LayoutEngineConfig(
+        workflowContext   = workflowContext
+            ?: error("koog-compose layout { }: workflowContext is required"),
+        slotRegistry      = slotRegistry
+            ?: error("koog-compose layout { }: slotRegistry is required"),
+        componentRegistry = componentRegistry
+            ?: error("koog-compose layout { }: componentRegistry is required"),
+        policy            = policy,
+    )
 }

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/PhaseSession.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/PhaseSession.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.prompt.executor.model.PromptExecutor
 import io.github.koogcompose.event.EventHandlers
 import io.github.koogcompose.event.KoogEvent
+import io.github.koogcompose.layout.DefaultLayoutDirectiveProcessor
 import io.github.koogcompose.observability.AgentEvent
 import io.github.koogcompose.phase.PhaseAwareAgent
 import kotlinx.coroutines.CoroutineScope
@@ -55,6 +56,12 @@ public class PhaseSession<S>(
 
     // ── New — pull sink from config so callers don't need to pass it ──────
     private val eventSink = context.config.eventSink
+
+    /** Layout engine processor, non-null only when [KoogComposeContext.layoutEngineConfig] is set. */
+    public val layoutProcessor: DefaultLayoutDirectiveProcessor? =
+        context.layoutEngineConfig?.let { cfg ->
+            DefaultLayoutDirectiveProcessor(cfg, scope)
+        }
 
     // ── Activity state ─────────────────────────────────────────────────────
 
@@ -119,6 +126,9 @@ public class PhaseSession<S>(
                 _activity.value = AgentActivity.Idle
                 _activityDetail.value = ""
             }
+
+            // Signal layout engine that a new turn is starting so in-flight coalescing resets.
+            layoutProcessor?.beginTurn()
 
             _activity.value = AgentActivity.Thinking
             _activityDetail.value = ""

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/PhasesessionHandle.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/session/PhasesessionHandle.kt
@@ -1,6 +1,7 @@
 package io.github.koogcompose.session
 
 import ai.koog.prompt.executor.model.PromptExecutor
+import io.github.koogcompose.layout.DefaultLayoutDirectiveProcessor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -72,6 +73,10 @@ public class PhaseSessionHandle<S>(
 
     public val turnId: StateFlow<Int>
         get() = delegate.turnId
+
+    /** Non-null when the session was built with a `layout { }` block. */
+    public val layoutProcessor: DefaultLayoutDirectiveProcessor?
+        get() = delegate.layoutProcessor
 }
 
 /**

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/EmitLayoutDirectiveTool.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/EmitLayoutDirectiveTool.kt
@@ -1,0 +1,259 @@
+package io.github.koogcompose.workflow
+
+import io.github.koogcompose.layout.AgentLayoutDirective
+import io.github.koogcompose.layout.ComponentId
+import io.github.koogcompose.layout.ComponentProps
+import io.github.koogcompose.layout.DirectiveId
+import io.github.koogcompose.layout.LayoutDirectiveProcessor
+import io.github.koogcompose.layout.LockMode
+import io.github.koogcompose.layout.Position
+import io.github.koogcompose.layout.SlotId
+import kotlinx.datetime.Clock
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Agent-facing tool that bridges a tool-calling LLM (Gemma 4, Claude, etc.) to
+ * [LayoutDirectiveProcessor]. This is the glue between your Koog dispatch loop and
+ * the Layer 1 engine.
+ *
+ * ## Integration steps
+ *
+ * **Step 1 — advertise the tool to the model.**
+ * Include [TOOL_SCHEMA_JSON] in your tool list when building the agent prompt. The
+ * schema body is model-agnostic; wrap it in the function-calling format your provider
+ * expects.
+ *
+ * **Step 2 — handle the tool call.**
+ * When your dispatch loop sees a tool call named [TOOL_NAME]:
+ * ```kotlin
+ * val tool = EmitLayoutDirectiveTool(processor, runtime)
+ * val result = tool.handle(call.argumentsJson)
+ * sendToolResult(call.id, result.toJson())
+ * ```
+ *
+ * **Step 3 — feed outcomes back.**
+ * Collect [LayoutDirectiveProcessor.outcomes] and inject each outcome as a system note
+ * into the next agent turn so the model can correct course on rejections/rewrites.
+ */
+public class EmitLayoutDirectiveTool(
+    private val processor: LayoutDirectiveProcessor,
+    private val runtime: WorkflowRuntime? = null,
+    private val correlationIdGenerator: () -> String = ::defaultCorrelationId,
+) {
+    /**
+     * Parses [rawArgsJson], validates against the current workflow phase, and submits
+     * the directive to [processor]. Returns immediately (non-blocking); the actual
+     * outcome arrives asynchronously via [LayoutDirectiveProcessor.outcomes].
+     */
+    public fun handle(rawArgsJson: String): ToolResult {
+        val args = try {
+            json.decodeFromString(EmitDirectiveArgs.serializer(), rawArgsJson)
+        } catch (t: Throwable) {
+            return ToolResult.Error("Could not parse arguments: ${t.message}")
+        }
+
+        val type = runCatching { DirectiveType.valueOf(args.directiveType) }.getOrNull()
+            ?: return ToolResult.Error(
+                "Unknown directiveType '${args.directiveType}'. Valid values: " +
+                    DirectiveType.values().joinToString { it.name }
+            )
+
+        if (runtime != null && !runtime.isDirectivePermittedNow(type)) {
+            return ToolResult.Error(
+                "Directive type '${type.name}' is not permitted in the current phase " +
+                    "'${runtime.currentPhase.value.value}'"
+            )
+        }
+
+        val directive = try {
+            buildDirective(type, args)
+        } catch (t: Throwable) {
+            return ToolResult.Error("Invalid directive arguments: ${t.message}")
+        }
+
+        processor.send(directive)
+        return ToolResult.Submitted(correlationId = directive.correlationId.value)
+    }
+
+    // ── Directive construction ────────────────────────────────────────────────
+
+    private fun buildDirective(type: DirectiveType, args: EmitDirectiveArgs): AgentLayoutDirective {
+        val corrId = DirectiveId(args.correlationId ?: correlationIdGenerator())
+        val now    = Clock.System.now()
+        val props  = ComponentProps(args.props ?: emptyMap())
+
+        return when (type) {
+            DirectiveType.Show -> AgentLayoutDirective.ShowComponent(
+                componentId   = ComponentId(req(args.componentId, "componentId")),
+                slotId        = SlotId(req(args.slotId, "slotId")),
+                position      = args.position?.toDomain() ?: Position.End,
+                props         = props,
+                correlationId = corrId,
+                issuedAt      = now,
+                reason        = args.reason,
+            )
+            DirectiveType.Hide -> AgentLayoutDirective.HideComponent(
+                componentId   = ComponentId(req(args.componentId, "componentId")),
+                slotId        = args.slotId?.let { SlotId(it) },
+                correlationId = corrId,
+                issuedAt      = now,
+                reason        = args.reason,
+            )
+            DirectiveType.Reorder -> AgentLayoutDirective.ReorderComponents(
+                slotId               = SlotId(req(args.slotId, "slotId")),
+                orderedComponentIds  = req(args.orderedComponentIds, "orderedComponentIds")
+                    .map { ComponentId(it) },
+                correlationId        = corrId,
+                issuedAt             = now,
+                reason               = args.reason,
+            )
+            DirectiveType.Swap -> AgentLayoutDirective.SwapComponent(
+                slotId            = SlotId(req(args.slotId, "slotId")),
+                removeComponentId = ComponentId(req(args.removeComponentId, "removeComponentId")),
+                insertComponentId = ComponentId(req(args.insertComponentId, "insertComponentId")),
+                props             = props,
+                correlationId     = corrId,
+                issuedAt          = now,
+                reason            = args.reason,
+            )
+            DirectiveType.Lock -> AgentLayoutDirective.LockComponent(
+                componentId   = ComponentId(req(args.componentId, "componentId")),
+                slotId        = SlotId(req(args.slotId, "slotId")),
+                lockMode      = parseLockMode(req(args.lockMode, "lockMode")),
+                correlationId = corrId,
+                issuedAt      = now,
+                reason        = args.reason,
+            )
+        }
+    }
+
+    private fun parseLockMode(raw: String): LockMode =
+        runCatching { LockMode.valueOf(raw) }.getOrElse {
+            error("Unknown lockMode '$raw'. Valid values: ${LockMode.values().joinToString { it.name }}")
+        }
+
+    // ── Result type ───────────────────────────────────────────────────────────
+
+    public sealed class ToolResult {
+        public abstract fun toJson(): String
+
+        public data class Submitted(val correlationId: String) : ToolResult() {
+            override fun toJson(): String =
+                """{"status":"submitted","correlationId":"$correlationId"}"""
+        }
+
+        public data class Error(val message: String) : ToolResult() {
+            override fun toJson(): String {
+                val escaped = message.replace("\\", "\\\\").replace("\"", "\\\"")
+                return """{"status":"error","message":"$escaped"}"""
+            }
+        }
+    }
+
+    // ── Companion ─────────────────────────────────────────────────────────────
+
+    public companion object {
+        public const val TOOL_NAME: String = "emit_layout_directive"
+
+        /**
+         * JSON Schema for advertising this tool to a tool-calling LLM. The schema body
+         * is provider-agnostic; wrap it in the function-calling envelope your provider
+         * requires (Anthropic `tools`, OpenAI `functions`, Gemma local function call, etc.).
+         */
+        public val TOOL_SCHEMA_JSON: String = """
+            {
+              "name": "$TOOL_NAME",
+              "description": "Modify the user interface by emitting a layout directive. Use this to show, hide, reorder, swap, or lock components in declared slots. Each call performs ONE directive. Always include a 'reason' field with a short justification.",
+              "parameters": {
+                "type": "object",
+                "required": ["directiveType", "reason"],
+                "properties": {
+                  "directiveType": {
+                    "type": "string",
+                    "enum": ["Show", "Hide", "Reorder", "Swap", "Lock"],
+                    "description": "The type of layout change to perform."
+                  },
+                  "componentId": { "type": "string", "description": "Target component id." },
+                  "slotId":      { "type": "string", "description": "Target slot id." },
+                  "position": {
+                    "type": "object",
+                    "description": "Where to insert the component. Defaults to End.",
+                    "properties": {
+                      "type":      { "type": "string", "enum": ["Start","End","Index","Before","After"] },
+                      "index":     { "type": "integer" },
+                      "reference": { "type": "string" }
+                    }
+                  },
+                  "orderedComponentIds": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "For Reorder: desired component order."
+                  },
+                  "removeComponentId": { "type": "string", "description": "For Swap: component to remove." },
+                  "insertComponentId": { "type": "string", "description": "For Swap: component to insert." },
+                  "lockMode": {
+                    "type": "string",
+                    "enum": ["ReadOnly", "Disabled", "Hidden"],
+                    "description": "For Lock: how to restrict the component."
+                  },
+                  "props": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" },
+                    "description": "Key-value props passed into the rendered component."
+                  },
+                  "reason": {
+                    "type": "string",
+                    "description": "Short justification for this change. Required."
+                  },
+                  "correlationId": {
+                    "type": "string",
+                    "description": "Optional caller-supplied id to match this directive to its outcome."
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        internal val json = Json { ignoreUnknownKeys = true }
+
+        private fun defaultCorrelationId(): String =
+            "dir-${Clock.System.now().toEpochMilliseconds()}-${(0..9999).random()}"
+
+        private fun <T : Any> req(value: T?, name: String): T =
+            value ?: error("Missing required field '$name'")
+    }
+}
+
+// ── Serializable arg types ────────────────────────────────────────────────────
+
+@Serializable
+internal data class EmitDirectiveArgs(
+    val directiveType: String,
+    val componentId: String? = null,
+    val slotId: String? = null,
+    val position: PositionArg? = null,
+    val orderedComponentIds: List<String>? = null,
+    val removeComponentId: String? = null,
+    val insertComponentId: String? = null,
+    val lockMode: String? = null,
+    val props: Map<String, String>? = null,
+    val reason: String? = null,
+    val correlationId: String? = null,
+)
+
+@Serializable
+internal data class PositionArg(
+    val type: String,
+    val index: Int? = null,
+    val reference: String? = null,
+)
+
+private fun PositionArg.toDomain(): Position = when (type) {
+    "Start"  -> Position.Start
+    "End"    -> Position.End
+    "Index"  -> Position.Index(index ?: error("Position.Index requires 'index'"))
+    "Before" -> Position.Before(ComponentId(reference ?: error("Position.Before requires 'reference'")))
+    "After"  -> Position.After(ComponentId(reference ?: error("Position.After requires 'reference'")))
+    else     -> error("Unknown Position type '$type'")
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/WorkflowDefinition.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/WorkflowDefinition.kt
@@ -1,0 +1,150 @@
+package io.github.koogcompose.workflow
+
+import io.github.koogcompose.layout.ComponentId
+import io.github.koogcompose.layout.ComponentProps
+import io.github.koogcompose.layout.Position
+import io.github.koogcompose.layout.SlotId
+import io.github.koogcompose.layout.UserRole
+import io.github.koogcompose.layout.WorkflowId
+import io.github.koogcompose.layout.WorkflowPolicy
+import kotlin.jvm.JvmInline
+
+/**
+ * The top-level declarative description of a workflow. Businesses configure this
+ * via the Kotlin DSL ([io.github.koogcompose.workflow.workflow]) or via JSON pushed
+ * from Layer 3 — both paths produce the same in-memory object through the same
+ * builders, so JSON workflows get identical validation.
+ *
+ * Compiles down to:
+ * - A [WorkflowPolicy] consumed by the Layer 1 policy chain
+ * - A list of [WorkflowPhase]s, each with its own system prompt and transitions
+ * - A map of [DefaultLayout]s — the initial UI before the agent has acted, keyed by role
+ */
+public data class WorkflowDefinition(
+    val id: WorkflowId,
+    val displayName: String,
+    val description: String,
+    val phases: List<WorkflowPhase>,
+    val initialPhase: PhaseId,
+    val defaultLayouts: Map<UserRoleId, DefaultLayout>,
+    val policy: WorkflowPolicy,
+    val triggers: List<TriggerDefinition>,
+) {
+    init {
+        require(phases.isNotEmpty()) { "WorkflowDefinition must declare at least one phase" }
+        require(phases.any { it.id == initialPhase }) {
+            "initialPhase ${initialPhase.value} must reference a declared phase"
+        }
+        val ids = phases.map { it.id }
+        require(ids.toSet().size == ids.size) { "Duplicate phase ids in workflow ${id.value}" }
+    }
+
+    public fun phase(id: PhaseId): WorkflowPhase =
+        phases.firstOrNull { it.id == id }
+            ?: error("No phase '${id.value}' in workflow '${this.id.value}'")
+}
+
+/** Stable identifier for a workflow phase. */
+@JvmInline
+public value class PhaseId(public val value: String) {
+    init { require(value.isNotBlank()) { "PhaseId must not be blank" } }
+}
+
+/** Stable string handle for a [UserRole], used in the JSON wire format. */
+@JvmInline
+public value class UserRoleId(public val value: String) {
+    init { require(value.isNotBlank()) { "UserRoleId must not be blank" } }
+}
+
+/**
+ * A discrete stage within a workflow. The agent receives [systemPrompt] when the
+ * workflow enters this phase. [permittedDirectiveTypes] narrows the directive
+ * vocabulary available to on-device models, reducing off-task behaviour.
+ */
+public data class WorkflowPhase(
+    val id: PhaseId,
+    val displayName: String,
+    val systemPrompt: String,
+    val permittedDirectiveTypes: Set<DirectiveType> = DirectiveType.All,
+    val transitions: List<PhaseTransition> = emptyList(),
+) {
+    init {
+        require(systemPrompt.isNotBlank()) { "Phase ${id.value} must have a non-blank systemPrompt" }
+        require(permittedDirectiveTypes.isNotEmpty()) {
+            "Phase ${id.value} must permit at least one directive type"
+        }
+    }
+}
+
+/** Which directive subtypes an agent may emit during a phase. */
+public enum class DirectiveType {
+    Show, Hide, Reorder, Swap, Lock;
+
+    public companion object {
+        public val All: Set<DirectiveType> = values().toSet()
+    }
+}
+
+/** A phase transition evaluated against incoming [WorkflowEvent]s. */
+public data class PhaseTransition(
+    val toPhase: PhaseId,
+    val condition: TransitionCondition,
+)
+
+public sealed class TransitionCondition {
+    /** Fires when a directive's reason field contains [reasonContains]. */
+    public data class OnAgentReason(val reasonContains: String) : TransitionCondition()
+
+    /** Fires when a host-emitted user action of [actionId] arrives. */
+    public data class OnUserAction(val actionId: String) : TransitionCondition()
+
+    /** Fires when data signal [signalKey] equals [equals]. */
+    public data class OnDataChange(val signalKey: String, val equals: String) : TransitionCondition()
+
+    /** Always fires immediately — used for unconditional sequencing. */
+    public data object Always : TransitionCondition()
+}
+
+/**
+ * The starting layout for a role before the agent has emitted anything. Each
+ * [DefaultPlacement] is applied as a synthetic [io.github.koogcompose.layout.AgentLayoutDirective.ShowComponent]
+ * through the standard reducer pipeline — default layouts can never violate policy.
+ */
+public data class DefaultLayout(val placements: List<DefaultPlacement>)
+
+public data class DefaultPlacement(
+    val componentId: ComponentId,
+    val slotId: SlotId,
+    val position: Position = Position.End,
+    val props: ComponentProps = ComponentProps.Empty,
+)
+
+/**
+ * A trigger declaration describing WHEN the agent should activate outside of direct
+ * user prompts. The host app wires its event sources to call
+ * [WorkflowRuntime.signal] — the runtime evaluates which triggers are active.
+ */
+public data class TriggerDefinition(
+    val id: TriggerId,
+    val displayName: String,
+    val activeInPhases: Set<PhaseId>,
+    val source: TriggerSource,
+)
+
+@JvmInline
+public value class TriggerId(public val value: String) {
+    init { require(value.isNotBlank()) { "TriggerId must not be blank" } }
+}
+
+public sealed class TriggerSource {
+    /** Agent runs every [intervalSeconds] while in an active phase. */
+    public data class Interval(val intervalSeconds: Int) : TriggerSource() {
+        init { require(intervalSeconds > 0) { "intervalSeconds must be positive" } }
+    }
+
+    /** Host fires this when a named UI action occurs. */
+    public data class UserAction(val actionId: String) : TriggerSource()
+
+    /** Host fires this when a watched data signal changes. */
+    public data class DataChange(val signalKey: String) : TriggerSource()
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/WorkflowDsl.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/WorkflowDsl.kt
@@ -1,0 +1,184 @@
+package io.github.koogcompose.workflow
+
+import io.github.koogcompose.layout.ComponentId
+import io.github.koogcompose.layout.ComponentProps
+import io.github.koogcompose.layout.LayoutInvariant
+import io.github.koogcompose.layout.Position
+import io.github.koogcompose.layout.RateLimit
+import io.github.koogcompose.layout.SlotAccess
+import io.github.koogcompose.layout.SlotId
+import io.github.koogcompose.layout.UserRole
+import io.github.koogcompose.layout.WorkflowId
+import io.github.koogcompose.layout.WorkflowPolicy
+
+/**
+ * Top-level entry point for declaring a workflow in Kotlin.
+ *
+ * ```kotlin
+ * val inventoryWorkflow = workflow(WorkflowId("daily_inventory")) {
+ *     displayName = "Daily Inventory Check"
+ *     description  = "Field agent walks SKUs; manager reviews on completion."
+ *
+ *     phase(PhaseId("intake")) {
+ *         displayName  = "Intake"
+ *         systemPrompt = "Show the inventory summary and the scan button."
+ *         permittedDirectives(DirectiveType.Show, DirectiveType.Hide)
+ *         transition(toPhase = PhaseId("scanning"), on = TransitionCondition.OnUserAction("scan_started"))
+ *     }
+ *
+ *     initialPhase = PhaseId("intake")
+ *
+ *     defaultLayout(role = FieldAgent) {
+ *         place(ComponentId("inventory_summary"), in_ = SlotId("primary"))
+ *     }
+ *
+ *     policy {
+ *         narrowSlotAccess(FieldAgent, SlotId("admin_panel"), SlotAccess.Hidden)
+ *     }
+ * }
+ * ```
+ */
+public fun workflow(id: WorkflowId, block: WorkflowBuilder.() -> Unit): WorkflowDefinition =
+    WorkflowBuilder(id).apply(block).build()
+
+@DslMarker
+public annotation class WorkflowDsl
+
+@WorkflowDsl
+public class WorkflowBuilder internal constructor(private val id: WorkflowId) {
+    public var displayName: String = ""
+    public var description: String = ""
+    public var initialPhase: PhaseId? = null
+
+    private val phases = mutableListOf<WorkflowPhase>()
+    private val defaultLayouts = mutableMapOf<UserRoleId, DefaultLayout>()
+    private val triggers = mutableListOf<TriggerDefinition>()
+    private val policyBuilder = WorkflowPolicyBuilder()
+
+    public fun phase(id: PhaseId, block: PhaseBuilder.() -> Unit) {
+        phases += PhaseBuilder(id).apply(block).build()
+    }
+
+    public fun defaultLayout(role: UserRole, block: DefaultLayoutBuilder.() -> Unit) {
+        defaultLayouts[UserRoleId(role.id)] = DefaultLayoutBuilder().apply(block).build()
+    }
+
+    public fun trigger(id: TriggerId, block: TriggerBuilder.() -> Unit) {
+        triggers += TriggerBuilder(id).apply(block).build()
+    }
+
+    public fun policy(block: WorkflowPolicyBuilder.() -> Unit) {
+        policyBuilder.apply(block)
+    }
+
+    internal fun build(): WorkflowDefinition {
+        require(displayName.isNotBlank()) { "Workflow ${id.value} must have a displayName" }
+        val initial = requireNotNull(initialPhase) { "Workflow ${id.value} must declare initialPhase" }
+        return WorkflowDefinition(
+            id             = id,
+            displayName    = displayName,
+            description    = description,
+            phases         = phases.toList(),
+            initialPhase   = initial,
+            defaultLayouts = defaultLayouts.toMap(),
+            policy         = policyBuilder.build(),
+            triggers       = triggers.toList(),
+        )
+    }
+}
+
+@WorkflowDsl
+public class PhaseBuilder internal constructor(private val id: PhaseId) {
+    public var displayName: String = ""
+    public var systemPrompt: String = ""
+
+    private var permitted: Set<DirectiveType> = DirectiveType.All
+    private val transitions = mutableListOf<PhaseTransition>()
+
+    public fun permittedDirectives(vararg types: DirectiveType) {
+        require(types.isNotEmpty()) { "Phase ${id.value}: permittedDirectives requires at least one type" }
+        permitted = types.toSet()
+    }
+
+    public fun transition(toPhase: PhaseId, on: TransitionCondition) {
+        transitions += PhaseTransition(toPhase, on)
+    }
+
+    internal fun build(): WorkflowPhase = WorkflowPhase(
+        id                     = id,
+        displayName            = displayName.ifBlank { id.value },
+        systemPrompt           = systemPrompt,
+        permittedDirectiveTypes = permitted,
+        transitions            = transitions.toList(),
+    )
+}
+
+@WorkflowDsl
+public class DefaultLayoutBuilder internal constructor() {
+    private val placements = mutableListOf<DefaultPlacement>()
+
+    /**
+     * Places [componentId] into slot [in_] at [position] with optional [props].
+     * Trailing underscore because `in` is a Kotlin keyword.
+     */
+    public fun place(
+        componentId: ComponentId,
+        `in_`: SlotId,
+        position: Position = Position.End,
+        props: ComponentProps = ComponentProps.Empty,
+    ) {
+        placements += DefaultPlacement(componentId, `in_`, position, props)
+    }
+
+    internal fun build(): DefaultLayout = DefaultLayout(placements.toList())
+}
+
+@WorkflowDsl
+public class TriggerBuilder internal constructor(private val id: TriggerId) {
+    public var displayName: String = ""
+    private var activeInPhases: Set<PhaseId> = emptySet()
+    private var source: TriggerSource? = null
+
+    public fun activeIn(vararg phases: PhaseId) { activeInPhases = phases.toSet() }
+    public fun fromInterval(seconds: Int) { source = TriggerSource.Interval(seconds) }
+    public fun fromUserAction(actionId: String) { source = TriggerSource.UserAction(actionId) }
+    public fun fromDataChange(signalKey: String) { source = TriggerSource.DataChange(signalKey) }
+
+    internal fun build(): TriggerDefinition {
+        require(activeInPhases.isNotEmpty()) { "Trigger ${id.value} must declare at least one active phase" }
+        return TriggerDefinition(
+            id             = id,
+            displayName    = displayName.ifBlank { id.value },
+            activeInPhases = activeInPhases,
+            source         = requireNotNull(source) { "Trigger ${id.value} must declare a source" },
+        )
+    }
+}
+
+@WorkflowDsl
+public class WorkflowPolicyBuilder internal constructor() {
+    private val slotOverrides = mutableMapOf<UserRole, MutableMap<SlotId, SlotAccess>>()
+    private val componentOverrides = mutableMapOf<ComponentId, MutableSet<UserRole>>()
+    private val invariants = mutableListOf<LayoutInvariant>()
+    public var rateLimit: RateLimit = RateLimit.Default
+
+    /** Narrows slot [slotId] access for [role]. Cannot widen what host policy granted. */
+    public fun narrowSlotAccess(role: UserRole, slotId: SlotId, access: SlotAccess) {
+        slotOverrides.getOrPut(role) { mutableMapOf() }[slotId] = access
+    }
+
+    /** Restricts [componentId] to [roles] for this workflow. Intersected with host-policy. */
+    public fun restrictComponentToRoles(componentId: ComponentId, roles: Set<UserRole>) {
+        require(roles.isNotEmpty()) { "Provide at least one role for component restriction" }
+        componentOverrides[componentId] = roles.toMutableSet()
+    }
+
+    public fun invariant(inv: LayoutInvariant) { invariants += inv }
+
+    internal fun build(): WorkflowPolicy = WorkflowPolicy(
+        slotAccessOverrides     = slotOverrides.mapValues { it.value.toMap() },
+        componentRoleOverrides  = componentOverrides.mapValues { it.value.toSet() },
+        invariants              = invariants.toList(),
+        rateLimit               = rateLimit,
+    )
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/WorkflowJson.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/WorkflowJson.kt
@@ -1,0 +1,357 @@
+package io.github.koogcompose.workflow
+
+import io.github.koogcompose.layout.ComponentId
+import io.github.koogcompose.layout.ComponentProps
+import io.github.koogcompose.layout.Position
+import io.github.koogcompose.layout.RateLimit
+import io.github.koogcompose.layout.SlotAccess
+import io.github.koogcompose.layout.SlotId
+import io.github.koogcompose.layout.UserRole
+import io.github.koogcompose.layout.WorkflowId
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Wire-format encode/decode for [WorkflowDefinition].
+ *
+ * Separate from the in-memory model so:
+ * - JSON shape is stable and versioned independently of the Kotlin types.
+ * - Loading goes through the same DSL builders as code-defined workflows — both
+ *   get identical init-time validation.
+ * - [io.github.koogcompose.layout.LayoutInvariant]s (arbitrary functions) are silently
+ *   dropped during decode: they cannot be expressed in a wire format. OTA workflows
+ *   that need invariants must reference them by id from a host-registered catalogue
+ *   (deferred to a future layer).
+ *
+ * **Schema versioning**: bump [SCHEMA_VERSION] on any breaking change. [decode] throws
+ * [WorkflowJsonException] when the document's version doesn't match.
+ */
+public object WorkflowJson {
+    public const val SCHEMA_VERSION: Int = 1
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = false
+        encodeDefaults = true
+    }
+
+    public fun encode(definition: WorkflowDefinition): String =
+        json.encodeToString(WorkflowDefinitionDto.serializer(), definition.toDto())
+
+    /**
+     * Decodes JSON into a [WorkflowDefinition] via the DSL builders.
+     *
+     * [roleResolver] maps role-id strings to [UserRole] instances. Throws
+     * [WorkflowJsonException] on any decoding or validation failure.
+     */
+    public fun decode(
+        rawJson: String,
+        roleResolver: (UserRoleId) -> UserRole?,
+    ): WorkflowDefinition {
+        val dto = try {
+            json.decodeFromString(WorkflowDefinitionDto.serializer(), rawJson)
+        } catch (t: Throwable) {
+            throw WorkflowJsonException("Malformed workflow JSON: ${t.message}", t)
+        }
+        if (dto.schemaVersion != SCHEMA_VERSION) {
+            throw WorkflowJsonException(
+                "Unsupported workflow schema version ${dto.schemaVersion}; expected $SCHEMA_VERSION"
+            )
+        }
+        return dto.toDefinition(roleResolver)
+    }
+}
+
+public class WorkflowJsonException(message: String, cause: Throwable? = null) :
+    RuntimeException(message, cause)
+
+// ── Wire DTOs ─────────────────────────────────────────────────────────────────
+
+@Serializable
+internal data class WorkflowDefinitionDto(
+    val schemaVersion: Int = WorkflowJson.SCHEMA_VERSION,
+    val id: String,
+    val displayName: String,
+    val description: String = "",
+    val phases: List<WorkflowPhaseDto>,
+    val initialPhase: String,
+    val defaultLayouts: Map<String, DefaultLayoutDto> = emptyMap(),
+    val policy: WorkflowPolicyDto = WorkflowPolicyDto(),
+    val triggers: List<TriggerDto> = emptyList(),
+)
+
+@Serializable
+internal data class WorkflowPhaseDto(
+    val id: String,
+    val displayName: String = "",
+    val systemPrompt: String,
+    val permittedDirectiveTypes: Set<String> = setOf("Show", "Hide", "Reorder", "Swap", "Lock"),
+    val transitions: List<TransitionDto> = emptyList(),
+)
+
+@Serializable
+internal data class TransitionDto(
+    val toPhase: String,
+    val condition: TransitionConditionDto,
+)
+
+@Serializable
+internal data class TransitionConditionDto(
+    val type: String,
+    val reasonContains: String? = null,
+    val actionId: String? = null,
+    val signalKey: String? = null,
+    val equals: String? = null,
+)
+
+@Serializable
+internal data class DefaultLayoutDto(
+    val placements: List<DefaultPlacementDto>,
+)
+
+@Serializable
+internal data class DefaultPlacementDto(
+    val componentId: String,
+    val slotId: String,
+    val position: PositionDto = PositionDto("End"),
+    val props: Map<String, String> = emptyMap(),
+)
+
+@Serializable
+internal data class PositionDto(
+    val type: String,
+    val index: Int? = null,
+    val reference: String? = null,
+)
+
+@Serializable
+internal data class WorkflowPolicyDto(
+    val slotAccessOverrides: Map<String, Map<String, String>> = emptyMap(),
+    val componentRoleOverrides: Map<String, Set<String>> = emptyMap(),
+    val rateLimit: RateLimitDto = RateLimitDto(),
+)
+
+@Serializable
+internal data class RateLimitDto(
+    val perTurn: Int = 20,
+    val perSession: Int = 500,
+    val coalescingWindowMs: Long = 16,
+)
+
+@Serializable
+internal data class TriggerDto(
+    val id: String,
+    val displayName: String = "",
+    val activeInPhases: Set<String>,
+    val source: TriggerSourceDto,
+)
+
+@Serializable
+internal data class TriggerSourceDto(
+    val type: String,
+    val intervalSeconds: Int? = null,
+    val actionId: String? = null,
+    val signalKey: String? = null,
+)
+
+// ── Encoding: model → DTO ─────────────────────────────────────────────────────
+
+private fun WorkflowDefinition.toDto() = WorkflowDefinitionDto(
+    id             = id.value,
+    displayName    = displayName,
+    description    = description,
+    phases         = phases.map { it.toDto() },
+    initialPhase   = initialPhase.value,
+    defaultLayouts = defaultLayouts.mapKeys { it.key.value }.mapValues { it.value.toDto() },
+    policy         = policy.toDto(),
+    triggers       = triggers.map { it.toDto() },
+)
+
+private fun WorkflowPhase.toDto() = WorkflowPhaseDto(
+    id                     = id.value,
+    displayName            = displayName,
+    systemPrompt           = systemPrompt,
+    permittedDirectiveTypes = permittedDirectiveTypes.map { it.name }.toSet(),
+    transitions            = transitions.map { it.toDto() },
+)
+
+private fun PhaseTransition.toDto() = TransitionDto(toPhase.value, condition.toDto())
+
+private fun TransitionCondition.toDto(): TransitionConditionDto = when (this) {
+    is TransitionCondition.OnAgentReason ->
+        TransitionConditionDto(type = "OnAgentReason", reasonContains = reasonContains)
+    is TransitionCondition.OnUserAction ->
+        TransitionConditionDto(type = "OnUserAction", actionId = actionId)
+    is TransitionCondition.OnDataChange ->
+        TransitionConditionDto(type = "OnDataChange", signalKey = signalKey, equals = equals)
+    TransitionCondition.Always ->
+        TransitionConditionDto(type = "Always")
+}
+
+private fun DefaultLayout.toDto() = DefaultLayoutDto(placements.map { it.toDto() })
+
+private fun DefaultPlacement.toDto() = DefaultPlacementDto(
+    componentId = componentId.value,
+    slotId      = slotId.value,
+    position    = position.toDto(),
+    props       = props.values,
+)
+
+private fun Position.toDto(): PositionDto = when (this) {
+    Position.Start         -> PositionDto("Start")
+    Position.End           -> PositionDto("End")
+    is Position.Index      -> PositionDto("Index", index = index)
+    is Position.Before     -> PositionDto("Before", reference = reference.value)
+    is Position.After      -> PositionDto("After", reference = reference.value)
+}
+
+private fun io.github.koogcompose.layout.WorkflowPolicy.toDto() = WorkflowPolicyDto(
+    slotAccessOverrides = slotAccessOverrides
+        .mapKeys { it.key.id }
+        .mapValues { (_, map) -> map.mapKeys { it.key.value }.mapValues { it.value.name } },
+    componentRoleOverrides = componentRoleOverrides
+        .mapKeys { it.key.value }
+        .mapValues { (_, roles) -> roles.map { it.id }.toSet() },
+    rateLimit = RateLimitDto(
+        perTurn            = rateLimit.perTurn,
+        perSession         = rateLimit.perSession,
+        coalescingWindowMs = rateLimit.coalescingWindow.inWholeMilliseconds,
+    ),
+)
+
+private fun TriggerDefinition.toDto() = TriggerDto(
+    id             = id.value,
+    displayName    = displayName,
+    activeInPhases = activeInPhases.map { it.value }.toSet(),
+    source         = source.toDto(),
+)
+
+private fun TriggerSource.toDto(): TriggerSourceDto = when (this) {
+    is TriggerSource.Interval    -> TriggerSourceDto("Interval", intervalSeconds = intervalSeconds)
+    is TriggerSource.UserAction  -> TriggerSourceDto("UserAction", actionId = actionId)
+    is TriggerSource.DataChange  -> TriggerSourceDto("DataChange", signalKey = signalKey)
+}
+
+// ── Decoding: DTO → model via DSL builders ────────────────────────────────────
+
+private fun WorkflowDefinitionDto.toDefinition(
+    roleResolver: (UserRoleId) -> UserRole?,
+): WorkflowDefinition = workflow(WorkflowId(id)) {
+    displayName  = this@toDefinition.displayName
+    description  = this@toDefinition.description
+    initialPhase = PhaseId(this@toDefinition.initialPhase)
+
+    for (phaseDto in phases) {
+        phase(PhaseId(phaseDto.id)) {
+            displayName  = phaseDto.displayName
+            systemPrompt = phaseDto.systemPrompt
+            val types = phaseDto.permittedDirectiveTypes
+                .mapNotNull { name -> runCatching { DirectiveType.valueOf(name) }.getOrNull() }
+            if (types.isNotEmpty()) permittedDirectives(*types.toTypedArray())
+            phaseDto.transitions.forEach { t ->
+                transition(toPhase = PhaseId(t.toPhase), on = t.condition.toDomain())
+            }
+        }
+    }
+
+    for ((roleIdStr, layoutDto) in defaultLayouts) {
+        val role = roleResolver(UserRoleId(roleIdStr))
+            ?: throw WorkflowJsonException(
+                "Workflow '$id' references unknown role '$roleIdStr' in defaultLayouts"
+            )
+        defaultLayout(role) {
+            layoutDto.placements.forEach { p ->
+                place(
+                    componentId = ComponentId(p.componentId),
+                    `in_`       = SlotId(p.slotId),
+                    position    = p.position.toDomain(),
+                    props       = ComponentProps(p.props),
+                )
+            }
+        }
+    }
+
+    for (triggerDto in triggers) {
+        trigger(TriggerId(triggerDto.id)) {
+            displayName = triggerDto.displayName
+            activeIn(*triggerDto.activeInPhases.map { PhaseId(it) }.toTypedArray())
+            triggerDto.source.applyTo(this, triggerDto.id)
+        }
+    }
+
+    policy {
+        for ((roleIdStr, slotMap) in this@toDefinition.policy.slotAccessOverrides) {
+            val role = roleResolver(UserRoleId(roleIdStr))
+                ?: throw WorkflowJsonException(
+                    "Workflow '$id' slot policy references unknown role '$roleIdStr'"
+                )
+            for ((slotStr, accessStr) in slotMap) {
+                val access = runCatching { SlotAccess.valueOf(accessStr) }.getOrNull()
+                    ?: throw WorkflowJsonException("Unknown SlotAccess '$accessStr'")
+                narrowSlotAccess(role, SlotId(slotStr), access)
+            }
+        }
+        for ((compIdStr, roleIds) in this@toDefinition.policy.componentRoleOverrides) {
+            val roles = roleIds.map { rid ->
+                roleResolver(UserRoleId(rid))
+                    ?: throw WorkflowJsonException(
+                        "Workflow '$id' componentRoleOverrides references unknown role '$rid'"
+                    )
+            }.toSet()
+            restrictComponentToRoles(ComponentId(compIdStr), roles)
+        }
+        rateLimit = RateLimit(
+            perTurn            = this@toDefinition.policy.rateLimit.perTurn,
+            perSession         = this@toDefinition.policy.rateLimit.perSession,
+            coalescingWindow   = this@toDefinition.policy.rateLimit.coalescingWindowMs.milliseconds,
+        )
+    }
+}
+
+private fun TriggerSourceDto.applyTo(builder: TriggerBuilder, triggerId: String) {
+    when (type) {
+        "Interval"   -> builder.fromInterval(
+            intervalSeconds ?: throw WorkflowJsonException("Trigger '$triggerId' Interval missing intervalSeconds")
+        )
+        "UserAction" -> builder.fromUserAction(
+            actionId ?: throw WorkflowJsonException("Trigger '$triggerId' UserAction missing actionId")
+        )
+        "DataChange" -> builder.fromDataChange(
+            signalKey ?: throw WorkflowJsonException("Trigger '$triggerId' DataChange missing signalKey")
+        )
+        else -> throw WorkflowJsonException("Trigger '$triggerId' unknown source type '$type'")
+    }
+}
+
+private fun TransitionConditionDto.toDomain(): TransitionCondition = when (type) {
+    "OnAgentReason" -> TransitionCondition.OnAgentReason(
+        reasonContains ?: throw WorkflowJsonException("OnAgentReason missing reasonContains")
+    )
+    "OnUserAction"  -> TransitionCondition.OnUserAction(
+        actionId ?: throw WorkflowJsonException("OnUserAction missing actionId")
+    )
+    "OnDataChange"  -> TransitionCondition.OnDataChange(
+        signalKey = signalKey ?: throw WorkflowJsonException("OnDataChange missing signalKey"),
+        equals    = equals    ?: throw WorkflowJsonException("OnDataChange missing equals"),
+    )
+    "Always"        -> TransitionCondition.Always
+    else            -> throw WorkflowJsonException("Unknown transition condition type '$type'")
+}
+
+private fun PositionDto.toDomain(): Position = when (type) {
+    "Start"  -> Position.Start
+    "End"    -> Position.End
+    "Index"  -> Position.Index(index ?: throw WorkflowJsonException("Position.Index missing index"))
+    "Before" -> Position.Before(
+        io.github.koogcompose.layout.ComponentId(
+            reference ?: throw WorkflowJsonException("Position.Before missing reference")
+        )
+    )
+    "After"  -> Position.After(
+        io.github.koogcompose.layout.ComponentId(
+            reference ?: throw WorkflowJsonException("Position.After missing reference")
+        )
+    )
+    else     -> throw WorkflowJsonException("Unknown Position type '$type'")
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/WorkflowRegistry.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/WorkflowRegistry.kt
@@ -1,0 +1,69 @@
+package io.github.koogcompose.workflow
+
+import io.github.koogcompose.layout.UserRole
+import io.github.koogcompose.layout.WorkflowId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Runtime store for [WorkflowDefinition]s, keyed by [WorkflowId].
+ *
+ * Thread-safe via a [Mutex]. Definitions are exposed as a [StateFlow] so consumers
+ * can react when definitions change at runtime (e.g., an OTA push lands mid-session).
+ *
+ * Semantics:
+ * - Registering a definition whose id already exists REPLACES the old one (OTA update).
+ * - Active sessions hold a snapshot reference — they see the OLD definition until the
+ *   next session start. Hot-swapping mid-session is deliberately unsupported.
+ * - The registry validates that every [UserRoleId] in [WorkflowDefinition.defaultLayouts]
+ *   resolves via [roleResolver] so JSON-loaded workflows can't silently reference roles
+ *   the host forgot to register.
+ */
+public class WorkflowRegistry(
+    private val roleResolver: (UserRoleId) -> UserRole?,
+) {
+    private val mutex = Mutex()
+    private val _definitions = MutableStateFlow<Map<WorkflowId, WorkflowDefinition>>(emptyMap())
+
+    public val definitions: StateFlow<Map<WorkflowId, WorkflowDefinition>> =
+        _definitions.asStateFlow()
+
+    public suspend fun register(definition: WorkflowDefinition) {
+        mutex.withLock {
+            validateRoles(definition)
+            _definitions.value = _definitions.value + (definition.id to definition)
+        }
+    }
+
+    public suspend fun registerAll(definitions: Iterable<WorkflowDefinition>) {
+        mutex.withLock {
+            definitions.forEach { validateRoles(it) }
+            _definitions.value = _definitions.value + definitions.associateBy { it.id }
+        }
+    }
+
+    public suspend fun unregister(id: WorkflowId) {
+        mutex.withLock {
+            _definitions.value = _definitions.value - id
+        }
+    }
+
+    public fun get(id: WorkflowId): WorkflowDefinition? = _definitions.value[id]
+
+    public fun require(id: WorkflowId): WorkflowDefinition =
+        get(id) ?: error("No workflow registered with id '${id.value}'")
+
+    public fun all(): Collection<WorkflowDefinition> = _definitions.value.values
+
+    private fun validateRoles(definition: WorkflowDefinition) {
+        for (roleId in definition.defaultLayouts.keys) {
+            requireNotNull(roleResolver(roleId)) {
+                "Workflow '${definition.id.value}' references unknown role '${roleId.value}'. " +
+                    "Register the role before loading this workflow."
+            }
+        }
+    }
+}

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/WorkflowRuntime.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/workflow/WorkflowRuntime.kt
@@ -1,0 +1,150 @@
+package io.github.koogcompose.workflow
+
+import io.github.koogcompose.layout.AgentLayoutDirective
+import io.github.koogcompose.layout.DirectiveId
+import io.github.koogcompose.layout.DirectiveOutcome
+import io.github.koogcompose.layout.LayoutDirectiveProcessor
+import io.github.koogcompose.layout.UserRole
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+
+/**
+ * Phase state machine that ties a [WorkflowDefinition] to a running
+ * [LayoutDirectiveProcessor].
+ *
+ * Responsibilities:
+ * - Apply the role's [DefaultLayout] at session start as synthetic [AgentLayoutDirective.ShowComponent]
+ *   directives, flowing through the same reducer pipeline so policy is enforced.
+ * - Expose [currentPhase] and [currentPhaseSystemPrompt] as [StateFlow]s so the agent
+ *   loop and host UI react to phase changes.
+ * - Evaluate phase transitions when external events arrive via [signal], or when a
+ *   directive's reason field matches an [TransitionCondition.OnAgentReason] condition.
+ *
+ * Thread-safety: all phase mutations are launched on [scope]; [StateFlow] consumers
+ * need no additional coordination.
+ */
+public class WorkflowRuntime(
+    public val definition: WorkflowDefinition,
+    public val role: UserRole,
+    private val processor: LayoutDirectiveProcessor,
+    private val scope: CoroutineScope,
+) {
+    private val _currentPhase = MutableStateFlow(definition.initialPhase)
+    public val currentPhase: StateFlow<PhaseId> = _currentPhase.asStateFlow()
+
+    private val _currentPhaseSystemPrompt = MutableStateFlow(
+        definition.phase(definition.initialPhase).systemPrompt
+    )
+
+    /**
+     * System prompt for the current phase. The agent loop reads this before each turn
+     * and uses it as the agent's system prompt. Updates reactively on phase transitions.
+     */
+    public val currentPhaseSystemPrompt: StateFlow<String> =
+        _currentPhaseSystemPrompt.asStateFlow()
+
+    private var outcomeJob: Job? = null
+
+    /**
+     * Applies the role's default layout as synthetic directives and begins observing
+     * directive outcomes for [TransitionCondition.OnAgentReason] transitions.
+     */
+    public suspend fun start() {
+        val layout = definition.defaultLayouts[UserRoleId(role.id)]
+        layout?.placements?.forEach { placement ->
+            processor.send(
+                AgentLayoutDirective.ShowComponent(
+                    componentId   = placement.componentId,
+                    slotId        = placement.slotId,
+                    position      = placement.position,
+                    props         = placement.props,
+                    correlationId = DirectiveId("default-${placement.componentId.value}-${placement.slotId.value}"),
+                    issuedAt      = Clock.System.now(),
+                    reason        = "default_layout",
+                )
+            )
+        }
+        observeAgentReasons()
+    }
+
+    /**
+     * Signals an external event. Transitions in the current phase's declaration order
+     * are evaluated; the first matching one fires. Unmatched events are silently ignored.
+     */
+    public fun signal(event: WorkflowEvent) {
+        scope.launch { evaluateTransitionsFor(event) }
+    }
+
+    /**
+     * Returns true when [type] is permitted in the current phase. The agent tool uses
+     * this to pre-validate directives before submitting them to the processor.
+     */
+    public fun isDirectivePermittedNow(type: DirectiveType): Boolean =
+        type in definition.phase(_currentPhase.value).permittedDirectiveTypes
+
+    public fun close() {
+        outcomeJob?.cancel()
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────────────
+
+    private fun observeAgentReasons() {
+        outcomeJob?.cancel()
+        outcomeJob = scope.launch {
+            processor.outcomes.collect { outcome ->
+                val reason = reasonFrom(outcome) ?: return@collect
+                evaluateTransitionsFor(WorkflowEvent.AgentReason(reason))
+            }
+        }
+    }
+
+    private fun reasonFrom(outcome: DirectiveOutcome): String? = when (outcome) {
+        is DirectiveOutcome.Accepted  -> outcome.directiveReason
+        is DirectiveOutcome.Rewritten -> outcome.final.reason
+        is DirectiveOutcome.Rejected  -> null
+        is DirectiveOutcome.Coalesced -> null
+    }
+
+    private fun evaluateTransitionsFor(event: WorkflowEvent) {
+        val phase = definition.phase(_currentPhase.value)
+        for (transition in phase.transitions) {
+            if (matches(transition.condition, event)) {
+                transitionTo(transition.toPhase)
+                return
+            }
+        }
+    }
+
+    private fun matches(condition: TransitionCondition, event: WorkflowEvent): Boolean =
+        when (condition) {
+            is TransitionCondition.OnAgentReason ->
+                event is WorkflowEvent.AgentReason && condition.reasonContains in event.reason
+            is TransitionCondition.OnUserAction  ->
+                event is WorkflowEvent.UserAction && event.actionId == condition.actionId
+            is TransitionCondition.OnDataChange  ->
+                event is WorkflowEvent.DataChange &&
+                    event.signalKey == condition.signalKey &&
+                    event.value == condition.equals
+            TransitionCondition.Always           -> true
+        }
+
+    private fun transitionTo(next: PhaseId) {
+        val phase = definition.phase(next)
+        _currentPhase.value = next
+        _currentPhaseSystemPrompt.value = phase.systemPrompt
+    }
+}
+
+/** An external event that may trigger a phase transition. */
+public sealed class WorkflowEvent {
+    public data class UserAction(val actionId: String) : WorkflowEvent()
+    public data class DataChange(val signalKey: String, val value: String) : WorkflowEvent()
+
+    /** Internal: emitted by the runtime when a directive's reason field is non-null. */
+    internal data class AgentReason(val reason: String) : WorkflowEvent()
+}

--- a/koog-compose-ui/src/commonMain/kotlin/io/github/koogcompose/ui/layout/LayoutHost.kt
+++ b/koog-compose-ui/src/commonMain/kotlin/io/github/koogcompose/ui/layout/LayoutHost.kt
@@ -1,0 +1,95 @@
+package io.github.koogcompose.ui.layout
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import io.github.koogcompose.layout.ComponentId
+import io.github.koogcompose.layout.ComponentProps
+import io.github.koogcompose.layout.DefaultLayoutDirectiveProcessor
+import io.github.koogcompose.layout.LayoutState
+import io.github.koogcompose.layout.LockMode
+import io.github.koogcompose.layout.SlotEntry
+import io.github.koogcompose.layout.SlotId
+
+/**
+ * Provides the composable content for a component given its [id] and current [props].
+ *
+ * Register one of these at startup in your ViewModel or DI graph and pass it down
+ * to every [LayoutSlotHost]. This keeps [koog-compose-core] free of Compose dependencies.
+ */
+public fun interface ComponentContentProvider {
+    @Composable
+    public fun Content(id: ComponentId, props: ComponentProps)
+}
+
+/**
+ * Renders the contents of [slotId] as reported by [processor].
+ *
+ * Each [SlotEntry] in the slot is passed to [contentProvider] in order.
+ * Components whose [SlotEntry.lockMode] is [LockMode.Hidden] are skipped entirely.
+ * Components with [LockMode.Disabled] or [LockMode.ReadOnly] are rendered — the
+ * host app's composable is responsible for applying the visual treatment (greyed-out,
+ * non-interactive) since koog-compose-ui has no knowledge of your design system.
+ *
+ * When [processor] is null (layout engine not configured) or the slot is empty,
+ * [emptyContent] is rendered instead. Defaults to rendering nothing.
+ *
+ * ### Example
+ * ```kotlin
+ * val provider = ComponentContentProvider { id, props ->
+ *     when (id.value) {
+ *         "promo_banner" -> PromoBanner(props)
+ *         "loyalty_card" -> LoyaltyCard(props)
+ *         else           -> Box(Modifier.fillMaxWidth().height(0.dp))
+ *     }
+ * }
+ *
+ * LayoutSlotHost(
+ *     slotId         = SlotId("hero"),
+ *     processor      = handle.layoutProcessor,
+ *     contentProvider = provider,
+ * )
+ * ```
+ */
+@Composable
+public fun LayoutSlotHost(
+    slotId: SlotId,
+    processor: DefaultLayoutDirectiveProcessor?,
+    contentProvider: ComponentContentProvider,
+    emptyContent: @Composable () -> Unit = {},
+) {
+    if (processor == null) {
+        emptyContent()
+        return
+    }
+
+    val layoutState by processor.layoutState.collectAsState()
+    LayoutSlotContent(
+        slotId = slotId,
+        layoutState = layoutState,
+        contentProvider = contentProvider,
+        emptyContent = emptyContent,
+    )
+}
+
+/**
+ * Stateless overload that accepts a pre-collected [LayoutState] snapshot.
+ * Useful when you want to hoist state collection out of this composable —
+ * e.g., to share it with sibling slots without extra subscriptions.
+ */
+@Composable
+public fun LayoutSlotContent(
+    slotId: SlotId,
+    layoutState: LayoutState,
+    contentProvider: ComponentContentProvider,
+    emptyContent: @Composable () -> Unit = {},
+) {
+    val entries = layoutState.entriesFor(slotId).filter { it.lockMode != LockMode.Hidden }
+    if (entries.isEmpty()) {
+        emptyContent()
+    } else {
+        for (entry in entries) {
+            contentProvider.Content(id = entry.componentId, props = entry.props)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces the complete Layer 1 layout engine — a declarative, policy-driven system for agent-controlled UI mutations. The engine processes layout directives through a multi-tier policy chain, applies them to immutable state via a pure reducer, and exposes outcomes back to the agent for closed-loop control.

## Key Changes

### Core Layout Engine
- **AgentLayoutDirective** — Sealed hierarchy of 5 directive types (Show, Hide, Reorder, Swap, Lock) that agents emit to mutate the layout. Each directive is idempotent and carries a correlation ID for tracing.
- **LayoutState & LayoutReducer** — Immutable state snapshot and pure reducer function. Supports slot capacity constraints (Single, Multiple with LRU eviction, Unbounded) and lock modes (ReadOnly, Disabled, Hidden).
- **LayoutDirectiveProcessor** — Actor-based processor that queues directives, applies policies, reduces state, and publishes outcomes. Single-threaded via a Channel to guarantee sequential mutation without locks.

### Policy Framework
- **LayoutPolicy** interface with three-tier chain: SDK (built-in validation) → Host (registered at startup) → Workflow (per-workflow overrides).
- **SdkLayoutPolicy** — Enforces schema validity, tag compatibility, permission checks, and lock-strengthening rules.
- **LayoutPolicyChain** — Chains policies in order; first Deny short-circuits, first Rewrite is applied and subsequent policies evaluate the rewritten directive.

### Workflow Definition & Runtime
- **WorkflowDefinition** — Top-level declarative description of a workflow with phases, transitions, default layouts, and policies.
- **WorkflowDsl** — Kotlin DSL for defining workflows in code with type-safe builders.
- **WorkflowJson** — Wire-format encoder/decoder for JSON workflows with schema versioning. Loads via the same DSL builders as code-defined workflows for identical validation.
- **WorkflowRuntime** — Phase state machine that ties a WorkflowDefinition to a running processor. Applies default layouts at session start, exposes phase/prompt as StateFlows, and evaluates transitions on external signals or directive reasons.
- **WorkflowRegistry** — Thread-safe runtime store for WorkflowDefinitions with hot-swap support for OTA updates.

### Agent Integration
- **EmitLayoutDirectiveTool** — Agent-facing tool that bridges tool-calling LLMs to the processor. Validates directives against the current phase, submits to processor, and returns correlation IDs for outcome tracking.

### UI Integration
- **LayoutHost** — Composable that renders slot contents from the processor's live LayoutState. Respects lock modes and delegates component rendering to a pluggable ContentProvider.

### Supporting Types
- **LayoutSlot, SlotRegistry, ComponentRegistry** — Immutable slot/component declarations and registries.
- **WorkflowContext** — Session-scoped context (business ID, user role, active workflow, device context).
- **WorkflowPolicy** — Rate limits, slot access overrides, component role overrides, and layout invariants.

## Notable Implementation Details

- **Single-threaded actor model** — All mutations (directives and turn signals) funnel through a Channel.UNLIMITED consumed by one coroutine, guaranteeing sequential state updates without external locks.
- **Idempotent directives** — All directive types are safe to replay; the reducer produces the same result on repeated application.
- **Policy-first design** — Policies run before reduction, allowing host/workflow tiers to rewrite or reject directives before state is mutated.
- **JSON schema versioning** — WorkflowJson includes a SCHEMA_VERSION constant; decode throws on mismatch to prevent silent incompatibilities.
- **Correlation IDs** — Every directive carries a DirectiveId for tracing; agents match outcomes to their emissions via this ID.
- **Slot capacity enforcement** — Single slots evict existing occupants; Multiple slots apply LRU eviction when full.
- **Lock modes** — Components can be locked ReadOnly, Disabled, or Hidden; the UI layer applies visual treatment based on the mode.

## Integration Points

- **KoogComposeContext** — Extended with optional `layoutEngine

https://claude.ai/code/session_01Nhfs1CTUg8HZHidxcwjdGc