### PR TITLE
fix(core): pass explicit KtorKoogHttpClient.Factory to LLM clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ This works because koog-compose bridges two things that usually live in separate
 
 ```kotlin
 dependencies {
-    implementation("io.github.brianmwas.koog_compose:koog-compose-core:1.4.2")
+    implementation("io.github.brianmwas.koog_compose:koog-compose-core:2.0.0")
 
     // Optional modules — add what you need
-    implementation("io.github.brianmwas.koog_compose:koog-compose-ui:1.4.2")           // Material 3 chat components
-    implementation("io.github.brianmwas.koog_compose:koog-compose-device:1.4.2")       // GPS, alarms, WorkManager (Android)
-    implementation("io.github.brianmwas.koog_compose:koog-compose-mediapipe:1.4.2")    // On-device models (Gemma 4, Apple FMs)
-    implementation("io.github.brianmwas.koog_compose:koog-compose-session-room:1.4.2") // Room-backed session persistence
-    implementation("io.github.brianmwas.koog_compose:koog-compose-testing:1.4.2")      // Test utilities
+    implementation("io.github.brianmwas.koog_compose:koog-compose-ui:2.0.0")           // Material 3 chat components
+    implementation("io.github.brianmwas.koog_compose:koog-compose-device:2.0.0")       // GPS, alarms, WorkManager (Android)
+    implementation("io.github.brianmwas.koog_compose:koog-compose-mediapipe:2.0.0")    // On-device models (Gemma 4, Apple FMs)
+    implementation("io.github.brianmwas.koog_compose:koog-compose-session-room:2.0.0") // Room-backed session persistence
+    implementation("io.github.brianmwas.koog_compose:koog-compose-testing:2.0.0")      // Test utilities
 }
 ```
 

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/provider/KoogaiProvider.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/provider/KoogaiProvider.kt
@@ -1,6 +1,7 @@
 package io.github.koogcompose.provider
 
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.http.client.ktor.KtorKoogHttpClient
 import ai.koog.prompt.cache.memory.InMemoryPromptCache
 import ai.koog.prompt.Prompt
 import ai.koog.prompt.dsl.prompt
@@ -204,15 +205,20 @@ public fun buildExecutor(config: ProviderConfig): PromptExecutor {
 internal fun buildClientForProvider(config: ProviderConfig): LLMClient = when (config) {
     is ProviderConfig.OpenAI -> OpenAILLMClient(
         apiKey = config.apiKey,
-        settings = OpenAIClientSettings(baseUrl = normalizeOpenAIBaseUrl(config.baseUrl))
+        settings = OpenAIClientSettings(baseUrl = normalizeOpenAIBaseUrl(config.baseUrl)),
+        httpClientFactory = KtorKoogHttpClient.Factory()
     )
 
     is ProviderConfig.Anthropic -> AnthropicLLMClient(
         apiKey = config.apiKey,
-        settings = AnthropicClientSettings()
+        settings = AnthropicClientSettings(),
+        httpClientFactory = KtorKoogHttpClient.Factory()
     )
 
-    is ProviderConfig.Ollama -> OllamaClient(config.baseUrl)
+    is ProviderConfig.Ollama -> OllamaClient(
+        httpClientFactory = KtorKoogHttpClient.Factory(),
+        baseUrl = config.baseUrl
+    )
     is ProviderConfig.LiteRtLm -> error(
         "koog-compose: LiteRT-LM requires :koog-compose-mediapipe module. " +
             "Use LiteRtLmProvider directly instead of KoogAIProvider."


### PR DESCRIPTION
koog 1.0.0 dropped the implicit HttpClient default for OpenAILLMClient, AnthropicLLMClient, and OllamaClient — JVM auto-discovers a Ktor factory via ServiceLoader, but Kotlin/Native (iOS) has none, so commonMain must supply ai.koog.http.client.ktor.KtorKoogHttpClient.Factory() explicitly (already on the classpath transitively via koog-agents).

Also bump the README's example dependency coordinates to 2.0.0 to match the published version.