### PR TITLE
Add comprehensive test suite for layout, security, and reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+# Runs the full test suite and the per-target compile gates on every change,
+# so failures (e.g. the iOS `compileKotlinIosSimulatorArm64` break that previously
+# only surfaced at publish time) are caught on each push and pull request — not
+# just when a release tag is cut.
+on:
+  push:
+    branches:
+      - main
+      - 'claude/**'
+  pull_request:
+    branches:
+      - main
+
+# Cancel superseded runs for the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test & compile / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false                  # let macos run even if ubuntu fails (and vice-versa)
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'            # koog 1.0.0 requires JDK 17
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v4
+        continue-on-error: true         # avoids ETIMEDOUT flakiness blocking the build
+
+      - name: Run tests (desktop)
+        run: ./gradlew desktopTest --no-configuration-cache --stacktrace
+
+      - name: Verify Android compilation
+        if: runner.os == 'Linux'        # ubuntu runners ship the Android SDK
+        run: ./gradlew :koog-compose-core:compileDebugKotlinAndroid --no-configuration-cache --stacktrace
+
+      - name: Verify iOS compilation
+        if: runner.os == 'macOS'
+        run: ./gradlew :koog-compose-core:compileKotlinIosSimulatorArm64 :koog-compose-testing:compileKotlinIosSimulatorArm64 --no-configuration-cache --stacktrace

--- a/README.md
+++ b/README.md
@@ -281,6 +281,40 @@ val displayText by remember {
 }.collectAsState(initial = "")
 ```
 
+### Generative UI layout
+
+The layout engine lets the agent drive *what UI is shown* through a small, declarative
+vocabulary instead of free-form code generation. The agent emits
+`AgentLayoutDirective`s — `ShowComponent`, `HideComponent`, `ReorderComponents`,
+`SwapComponent`, `LockComponent` — into named, host-declared **slots**. Each directive
+runs through a validation pipeline (`SchemaValidation → PolicyCheck → SlotConstraintCheck
+→ Reduce`) before it touches the live `LayoutState` your Compose UI renders.
+
+Every directive carries a `correlationId`, and the engine publishes a `DirectiveOutcome`
+the agent reads back on its next turn:
+
+| Outcome | Meaning |
+|---------|---------|
+| `Accepted` | Applied as-is. |
+| `Rewritten` | Modified by policy before applying (e.g. evict-then-show on a Single slot). |
+| `Rejected` | Dropped; `rejectedAt` names the pipeline stage that refused it. |
+| `Coalesced` | Deduplicated against an in-flight directive with the same `correlationId`. |
+
+**`positionFallback`** — `ShowComponent` can request a relative `Position.Before(ref)` or
+`Position.After(ref)`. If the referenced component isn't in the slot, the engine silently
+appends to the end instead of rejecting the directive. When that happens, the `Accepted`
+(or `Rewritten`) outcome carries `positionFallback = true`, so the agent can detect that
+its requested ordering wasn't honored and correct course on the next turn:
+
+```kotlin
+processor.outcomes.collect { outcome ->
+    if (outcome is DirectiveOutcome.Accepted && outcome.positionFallback) {
+        // The Before/After reference was missing — component went to the end.
+        // The agent can re-issue a ReorderComponents directive if ordering matters.
+    }
+}
+```
+
 ---
 
 ## Testing
@@ -419,6 +453,8 @@ Events emitted at runtime:
 | `GuardrailDenied` | Tool blocked by rate limit, allowlist, or user refusal | Security/compliance audit, UX friction |
 | `AgentStuck` | LLM repeats the same phase N times | Loop detection, fallback messaging |
 | `TurnFailed` | Retry exhausted after N attempts | Error rates, provider reliability |
+| `CircuitBreakerOpened` | A `CircuitBreakerGuard` trips OPEN after repeated failures | Degraded-mode banners, dependency alerting |
+| `CircuitBreakerClosed` | A tripped breaker recovers to CLOSED | Recovery tracking, clearing degraded UI |
 | `LLMRequested` | (Reserved for future use) | — |
 
 Implement a custom sink by extending `EventSink`:
@@ -730,6 +766,22 @@ States:
 - **CLOSED** (normal) → failures counted
 - **OPEN** (broken) → calls rejected immediately
 - **HALF_OPEN** (trial) → one success closes it, one failure reopens
+
+Pass a `sessionId` and an `EventSink` to observe state transitions — the guard emits
+`AgentEvent.CircuitBreakerOpened` when it trips and `AgentEvent.CircuitBreakerClosed`
+when it recovers, so you can surface degraded-mode banners or alert your backend:
+
+```kotlin
+val tool = CircuitBreakerGuard(
+    delegate = SavePhotoTool(stateStore),
+    circuitBreaker = breaker,
+    sessionId = session.id,
+    eventSink = myEventSink,   // routes to Firebase / Datadog / logs
+)
+```
+
+Both parameters are optional (default: no session id, `NoOpEventSink`), so existing
+call sites keep working unchanged.
 
 ### Session Corruption Recovery
 

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/AgentLayoutDirective.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/AgentLayoutDirective.kt
@@ -137,6 +137,8 @@ public sealed class DirectiveOutcome {
         override val correlationId: DirectiveId,
         override val resultingStateVersion: Long,
         public val directiveReason: String? = null,
+        /** True if a requested [Position.Before]/[Position.After] silently fell back to [Position.End]. */
+        public val positionFallback: Boolean = false,
     ) : DirectiveOutcome()
 
     /**
@@ -149,6 +151,8 @@ public sealed class DirectiveOutcome {
         public val final: AgentLayoutDirective,
         public val reason: String,
         override val resultingStateVersion: Long,
+        /** True if [final]'s requested [Position.Before]/[Position.After] silently fell back to [Position.End]. */
+        public val positionFallback: Boolean = false,
     ) : DirectiveOutcome()
 
     /** Directive dropped entirely. State is unchanged. */

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutDirectiveProcessor.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutDirectiveProcessor.kt
@@ -133,6 +133,7 @@ public class DefaultLayoutDirectiveProcessor(
         val state = _layoutState.value
         when (val decision = effectivePolicy.evaluate(directive, state, config.workflowContext)) {
             is PolicyDecision.Allow -> {
+                val fallback = LayoutReducer.positionFallsBackToEnd(state, directive)
                 val newState = LayoutReducer.apply(state, directive, config.slotRegistry)
                 _layoutState.value = newState
                 _outcomes.emit(
@@ -140,12 +141,14 @@ public class DefaultLayoutDirectiveProcessor(
                         correlationId = directive.correlationId,
                         resultingStateVersion = newState.version,
                         directiveReason = directive.reason,
+                        positionFallback = fallback,
                     )
                 )
             }
 
             is PolicyDecision.Rewrite -> {
                 val finalDirective = decision.replacement
+                val fallback = LayoutReducer.positionFallsBackToEnd(state, finalDirective)
                 val newState = LayoutReducer.apply(state, finalDirective, config.slotRegistry)
                 _layoutState.value = newState
                 _outcomes.emit(
@@ -155,6 +158,7 @@ public class DefaultLayoutDirectiveProcessor(
                         final = finalDirective,
                         reason = decision.reason,
                         resultingStateVersion = newState.version,
+                        positionFallback = fallback,
                     )
                 )
             }

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutReducer.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/layout/LayoutReducer.kt
@@ -29,6 +29,24 @@ public object LayoutReducer {
         is AgentLayoutDirective.LockComponent     -> applyLock(state, directive)
     }
 
+    /**
+     * True if applying [directive] to [state] would silently fall back a
+     * [Position.Before]/[Position.After] insertion to [Position.End] because the
+     * referenced component is not currently in the target slot.
+     *
+     * Lets [DefaultLayoutDirectiveProcessor] surface this on the emitted
+     * [DirectiveOutcome] so the agent can notice its requested position was ignored.
+     */
+    public fun positionFallsBackToEnd(state: LayoutState, directive: AgentLayoutDirective): Boolean {
+        if (directive !is AgentLayoutDirective.ShowComponent) return false
+        val reference = when (val position = directive.position) {
+            is Position.Before -> position.reference
+            is Position.After -> position.reference
+            else -> return false
+        }
+        return state.entriesFor(directive.slotId).none { it.componentId == reference }
+    }
+
     // ── ShowComponent ──────────────────────────────────────────────────────
 
     private fun applyShow(

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/observability/AgentEvent.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/observability/AgentEvent.kt
@@ -62,6 +62,27 @@ public sealed class AgentEvent {
         val message: String,
         override val timestampMs: Long = currentTimeMs(),
     ) : AgentEvent()
+
+    /**
+     * A [io.github.koogcompose.reliability.CircuitBreaker] tripped to OPEN after
+     * repeated failures. Calls to [toolName] are rejected for [cooldownMs] ms.
+     */
+    public data class CircuitBreakerOpened(
+        val sessionId: String,
+        val toolName: String,
+        val cooldownMs: Long,
+        override val timestampMs: Long = currentTimeMs(),
+    ) : AgentEvent()
+
+    /**
+     * A [io.github.koogcompose.reliability.CircuitBreaker] recovered to CLOSED
+     * after successful trial calls. [toolName] is healthy again.
+     */
+    public data class CircuitBreakerClosed(
+        val sessionId: String,
+        val toolName: String,
+        override val timestampMs: Long = currentTimeMs(),
+    ) : AgentEvent()
 }
 
 // expect/actual so commonMain compiles without java.lang.System

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/provider/KoogaiProvider.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/provider/KoogaiProvider.kt
@@ -161,9 +161,10 @@ internal class KoogAIProvider<S>(
             }
         }.ifEmpty { null }
 
+        val defaults = providerConfig.generationDefaults()
         return LLMParams(
-            temperature = configParams?.temperature ?: providerConfig.defaultTemperature(),
-            maxTokens = configParams?.maxTokens ?: providerConfig.defaultMaxTokens(),
+            temperature = configParams?.temperature ?: defaults.temperature,
+            maxTokens = configParams?.maxTokens ?: defaults.maxTokens,
             additionalProperties = additionalProperties
         )
     }
@@ -388,22 +389,20 @@ private fun String.asCustomModel(fallback: LLModel): LLModel = LLModel(
     maxOutputTokens = fallback.maxOutputTokens
 )
 
-private fun ProviderConfig.defaultTemperature(): Double? = when (this) {
-    is ProviderConfig.Anthropic -> temperature
-    is ProviderConfig.Ollama -> temperature
-    is ProviderConfig.OpenAI -> temperature
-    is ProviderConfig.LiteRtLm -> null
-    is ProviderConfig.OnDevice -> null
-    is ProviderConfig.Router -> providers.firstOrNull()?.defaultTemperature()
-}
+/**
+ * Resolved default generation parameters for a [ProviderConfig], used to fill
+ * in [LLMParams] when the caller hasn't supplied explicit `llmParams`.
+ */
+internal data class GenerationDefaults(val temperature: Double?, val maxTokens: Int?)
 
-private fun ProviderConfig.defaultMaxTokens(): Int? = when (this) {
-    is ProviderConfig.Anthropic -> maxTokens
-    is ProviderConfig.Ollama -> maxTokens
-    is ProviderConfig.OpenAI -> maxTokens
-    is ProviderConfig.LiteRtLm -> maxTokens
-    is ProviderConfig.OnDevice -> null
-    is ProviderConfig.Router -> providers.firstOrNull()?.defaultMaxTokens()
+internal fun ProviderConfig.generationDefaults(): GenerationDefaults = when (this) {
+    is ProviderConfig.Anthropic -> GenerationDefaults(temperature, maxTokens)
+    is ProviderConfig.Ollama -> GenerationDefaults(temperature, maxTokens)
+    is ProviderConfig.OpenAI -> GenerationDefaults(temperature, maxTokens)
+    is ProviderConfig.LiteRtLm -> GenerationDefaults(temperature = null, maxTokens = maxTokens)
+    is ProviderConfig.OnDevice -> GenerationDefaults(temperature = null, maxTokens = null)
+    is ProviderConfig.Router -> providers.firstOrNull()?.generationDefaults()
+        ?: GenerationDefaults(temperature = null, maxTokens = null)
 }
 
 private fun String.toJsonObjectSafe(): JsonObject = try {

--- a/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/reliability/CircuitBreaker.kt
+++ b/koog-compose-core/src/commonMain/kotlin/io/github/koogcompose/reliability/CircuitBreaker.kt
@@ -1,5 +1,8 @@
 package io.github.koogcompose.reliability
 
+import io.github.koogcompose.observability.AgentEvent
+import io.github.koogcompose.observability.EventSink
+import io.github.koogcompose.observability.NoOpEventSink
 import io.github.koogcompose.observability.currentTimeMs
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -85,23 +88,29 @@ public class CircuitBreaker(
         }
     }
 
-    internal suspend fun recordSuccess() = mutex.withLock {
+    /** Records a success. Returns true if the circuit transitioned HALF_OPEN → CLOSED. */
+    internal suspend fun recordSuccess(): Boolean = mutex.withLock {
         failureCount = 0
         if (state == State.HALF_OPEN) {
             successCount++
             if (successCount >= successThreshold) {
                 state = State.CLOSED
+                return@withLock true
             }
         }
+        false
     }
 
-    internal suspend fun recordFailure() = mutex.withLock {
+    /** Records a failure. Returns true if the circuit transitioned to OPEN. */
+    internal suspend fun recordFailure(): Boolean = mutex.withLock {
         failureCount++
         if (state == State.HALF_OPEN || failureCount >= failureThreshold) {
             state = State.OPEN
             openedAtMs = currentTimeMs()
             failureCount = 0
+            return@withLock true
         }
+        false
     }
 
     /** Returns true if the circuit is currently open and rejecting calls. */
@@ -141,6 +150,8 @@ public class CircuitOpenException(message: String) : Exception(message)
 public class CircuitBreakerGuard(
     private val delegate: io.github.koogcompose.tool.SecureTool,
     private val circuitBreaker: CircuitBreaker,
+    private val sessionId: String = "",
+    private val eventSink: EventSink = NoOpEventSink,
 ) : io.github.koogcompose.tool.SecureTool by delegate {
 
     override suspend fun execute(args: kotlinx.serialization.json.JsonObject)
@@ -169,11 +180,20 @@ public class CircuitBreakerGuard(
         val result = delegate.execute(args)
 
         // Count ToolResult.Failure as a circuit breaker failure
-        // but NOT ToolResult.Denied (user/policy denials aren't service failures)
+        // but NOT ToolResult.Denied (user/policy denials aren't service failures).
+        // Emit an observability event when a state transition occurs.
         when (result) {
             is io.github.koogcompose.tool.ToolResult.Success,
-            is io.github.koogcompose.tool.ToolResult.Structured<*> -> circuitBreaker.recordSuccess()
-            is io.github.koogcompose.tool.ToolResult.Failure -> circuitBreaker.recordFailure()
+            is io.github.koogcompose.tool.ToolResult.Structured<*> ->
+                if (circuitBreaker.recordSuccess()) {
+                    eventSink.emit(AgentEvent.CircuitBreakerClosed(sessionId, delegate.name))
+                }
+            is io.github.koogcompose.tool.ToolResult.Failure ->
+                if (circuitBreaker.recordFailure()) {
+                    eventSink.emit(
+                        AgentEvent.CircuitBreakerOpened(sessionId, delegate.name, circuitBreaker.cooldownMs)
+                    )
+                }
             is io.github.koogcompose.tool.ToolResult.Denied -> Unit // Don't count as failure
         }
 

--- a/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/layout/DefaultLayoutDirectiveProcessorTest.kt
+++ b/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/layout/DefaultLayoutDirectiveProcessorTest.kt
@@ -1,0 +1,147 @@
+package io.github.koogcompose.layout
+
+import app.cash.turbine.test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultLayoutDirectiveProcessorTest {
+
+    @Test
+    fun validShowComponent_isAccepted_andUpdatesLayoutState() = runTest {
+        val processor = DefaultLayoutDirectiveProcessor(testConfig(), scope = this)
+
+        processor.outcomes.test {
+            processor.send(show("a", HERO, Position.End, DirectiveId("d1")))
+            advanceUntilIdle()
+
+            val outcome = awaitItem()
+            assertTrue(outcome is DirectiveOutcome.Accepted)
+            outcome as DirectiveOutcome.Accepted
+            assertEquals(DirectiveId("d1"), outcome.correlationId)
+            assertEquals(1L, outcome.resultingStateVersion)
+            assertFalse(outcome.positionFallback)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertEquals(listOf("a"), processor.layoutState.value.entriesFor(HERO).map { it.componentId.value })
+    }
+
+    @Test
+    fun showComponent_unknownComponent_isRejected() = runTest {
+        val processor = DefaultLayoutDirectiveProcessor(testConfig(), scope = this)
+
+        processor.outcomes.test {
+            processor.send(show("unknown", HERO, Position.End, DirectiveId("d1")))
+            advanceUntilIdle()
+
+            val outcome = awaitItem()
+            assertTrue(outcome is DirectiveOutcome.Rejected)
+            outcome as DirectiveOutcome.Rejected
+            assertEquals(PipelineStage.SchemaValidation, outcome.rejectedAt)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertTrue(processor.layoutState.value.isEmpty())
+    }
+
+    @Test
+    fun duplicateCorrelationId_withinTurn_isCoalesced() = runTest {
+        val processor = DefaultLayoutDirectiveProcessor(testConfig(), scope = this)
+        val directive = show("a", HERO, Position.End, DirectiveId("dup"))
+
+        processor.outcomes.test {
+            processor.send(directive)
+            advanceUntilIdle()
+            assertTrue(awaitItem() is DirectiveOutcome.Accepted)
+
+            processor.send(directive)
+            advanceUntilIdle()
+            assertTrue(awaitItem() is DirectiveOutcome.Coalesced)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun beginTurn_resetsCoalescing_soRepeatedCorrelationIdIsProcessedAgain() = runTest {
+        val processor = DefaultLayoutDirectiveProcessor(testConfig(), scope = this)
+        val directive = show("a", HERO, Position.End, DirectiveId("dup"))
+
+        processor.outcomes.test {
+            processor.send(directive)
+            advanceUntilIdle()
+            assertTrue(awaitItem() is DirectiveOutcome.Accepted)
+
+            processor.beginTurn()
+            processor.send(directive)
+            advanceUntilIdle()
+            assertTrue(awaitItem() is DirectiveOutcome.Accepted)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun showComponent_positionBeforeMissingReference_surfacesPositionFallback() = runTest {
+        val processor = DefaultLayoutDirectiveProcessor(testConfig(), scope = this)
+
+        processor.outcomes.test {
+            processor.send(show("a", HERO, Position.Before(ComponentId("b")), DirectiveId("d1")))
+            advanceUntilIdle()
+
+            val outcome = awaitItem()
+            assertTrue(outcome is DirectiveOutcome.Accepted)
+            outcome as DirectiveOutcome.Accepted
+            assertTrue(outcome.positionFallback)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertEquals(listOf("a"), processor.layoutState.value.entriesFor(HERO).map { it.componentId.value })
+    }
+}
+
+private val HERO = SlotId("hero")
+private val PROMO_TAG = Tag("promo")
+
+private fun testConfig(): LayoutEngineConfig = LayoutEngineConfig(
+    workflowContext = WorkflowContext(
+        businessId = BusinessId("biz-1"),
+        userRole = TestUserRole(setOf(Permissions.Read)),
+        activeWorkflow = WorkflowId("wf-1"),
+        deviceContext = DeviceContext(Platform.Android, FormFactor.Phone, NetworkClass.Online, "en-US"),
+    ),
+    slotRegistry = SlotRegistry(listOf(LayoutSlot(HERO, SlotCapacity.Multiple(3), setOf(PROMO_TAG)))),
+    componentRegistry = ComponentRegistry(
+        listOf(
+            ComponentDefinition(ComponentId("a"), setOf(PROMO_TAG)),
+            ComponentDefinition(ComponentId("b"), setOf(PROMO_TAG)),
+        )
+    ),
+)
+
+private fun show(
+    componentId: String,
+    slotId: SlotId,
+    position: Position,
+    correlationId: DirectiveId,
+): AgentLayoutDirective.ShowComponent = AgentLayoutDirective.ShowComponent(
+    componentId = ComponentId(componentId),
+    slotId = slotId,
+    position = position,
+    correlationId = correlationId,
+)
+
+private class TestUserRole(permissions: Set<Permission>) : UserRole(
+    id = "viewer",
+    displayName = "Viewer",
+    permissions = permissions,
+)

--- a/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/layout/LayoutReducerTest.kt
+++ b/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/layout/LayoutReducerTest.kt
@@ -1,0 +1,371 @@
+package io.github.koogcompose.layout
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class LayoutReducerTest {
+
+    // ── ShowComponent: positions ───────────────────────────────────────────
+
+    @Test
+    fun showComponent_addsEntryAtEnd() {
+        val result = LayoutReducer.apply(LayoutState.Empty, show("a", HERO, Position.End))
+
+        assertEquals(listOf("a"), result.entriesFor(HERO).map { it.componentId.value })
+        assertEquals(1L, result.version)
+    }
+
+    @Test
+    fun showComponent_positionStart_insertsAtFront() {
+        val state = stateWith(HERO, entry("a"), entry("b"))
+
+        val result = LayoutReducer.apply(state, show("c", HERO, Position.Start))
+
+        assertEquals(listOf("c", "a", "b"), result.entriesFor(HERO).map { it.componentId.value })
+    }
+
+    @Test
+    fun showComponent_positionIndex_clampedToSize() {
+        val state = stateWith(HERO, entry("a"), entry("b"))
+
+        val result = LayoutReducer.apply(state, show("c", HERO, Position.Index(10)))
+
+        assertEquals(listOf("a", "b", "c"), result.entriesFor(HERO).map { it.componentId.value })
+    }
+
+    @Test
+    fun showComponent_positionBefore_insertsBeforeReference() {
+        val state = stateWith(HERO, entry("a"), entry("b"))
+
+        val result = LayoutReducer.apply(state, show("c", HERO, Position.Before(ComponentId("b"))))
+
+        assertEquals(listOf("a", "c", "b"), result.entriesFor(HERO).map { it.componentId.value })
+    }
+
+    @Test
+    fun showComponent_positionAfter_insertsAfterReference() {
+        val state = stateWith(HERO, entry("a"), entry("b"))
+
+        val result = LayoutReducer.apply(state, show("c", HERO, Position.After(ComponentId("a"))))
+
+        assertEquals(listOf("a", "c", "b"), result.entriesFor(HERO).map { it.componentId.value })
+    }
+
+    @Test
+    fun showComponent_positionBefore_missingReference_fallsBackToEnd() {
+        val state = stateWith(HERO, entry("a"))
+
+        val result = LayoutReducer.apply(state, show("c", HERO, Position.Before(ComponentId("missing"))))
+
+        assertEquals(listOf("a", "c"), result.entriesFor(HERO).map { it.componentId.value })
+    }
+
+    @Test
+    fun showComponent_positionAfter_missingReference_fallsBackToEnd() {
+        val state = stateWith(HERO, entry("a"))
+
+        val result = LayoutReducer.apply(state, show("c", HERO, Position.After(ComponentId("missing"))))
+
+        assertEquals(listOf("a", "c"), result.entriesFor(HERO).map { it.componentId.value })
+    }
+
+    // ── ShowComponent: re-show ─────────────────────────────────────────────
+
+    @Test
+    fun showComponent_reShow_preservesAddedAtAndUpdatesPropsAndPosition() {
+        val originalTime = Instant.fromEpochMilliseconds(1_000)
+        val newTime = Instant.fromEpochMilliseconds(2_000)
+        val state = LayoutState(
+            slots = mapOf(
+                HERO to listOf(
+                    SlotEntry(ComponentId("a"), ComponentProps(mapOf("k" to "v1")), addedAt = originalTime),
+                    SlotEntry(ComponentId("b"), ComponentProps.Empty, addedAt = originalTime),
+                )
+            )
+        )
+        val directive = AgentLayoutDirective.ShowComponent(
+            componentId = ComponentId("a"),
+            slotId = HERO,
+            position = Position.Start,
+            props = ComponentProps(mapOf("k" to "v2")),
+            correlationId = DirectiveId("d1"),
+            issuedAt = newTime,
+        )
+
+        val result = LayoutReducer.apply(state, directive, now = newTime)
+
+        val entries = result.entriesFor(HERO)
+        assertEquals(listOf("a", "b"), entries.map { it.componentId.value })
+        val a = entries.first { it.componentId.value == "a" }
+        assertEquals(originalTime, a.addedAt)
+        assertEquals("v2", a.props.get("k"))
+    }
+
+    // ── ShowComponent: slot capacity ───────────────────────────────────────
+
+    @Test
+    fun showComponent_singleCapacity_evictsExisting() {
+        val slotRegistry = SlotRegistry(listOf(LayoutSlot(HERO, SlotCapacity.Single, setOf(Tag("promo")))))
+        val state = stateWith(HERO, entry("a"))
+
+        val result = LayoutReducer.apply(state, show("b", HERO, Position.End), slotRegistry)
+
+        assertEquals(listOf("b"), result.entriesFor(HERO).map { it.componentId.value })
+    }
+
+    @Test
+    fun showComponent_multipleCapacity_evictsOldestWhenFull() {
+        val slotRegistry = SlotRegistry(listOf(LayoutSlot(HERO, SlotCapacity.Multiple(2), setOf(Tag("promo")))))
+        val state = stateWith(HERO, entry("a"), entry("b"))
+
+        val result = LayoutReducer.apply(state, show("c", HERO, Position.End), slotRegistry)
+
+        assertEquals(listOf("b", "c"), result.entriesFor(HERO).map { it.componentId.value })
+    }
+
+    @Test
+    fun showComponent_unboundedCapacity_doesNotEvict() {
+        val slotRegistry = SlotRegistry(listOf(LayoutSlot(HERO, SlotCapacity.Unbounded, setOf(Tag("promo")))))
+        val state = stateWith(HERO, entry("a"), entry("b"))
+
+        val result = LayoutReducer.apply(state, show("c", HERO, Position.End), slotRegistry)
+
+        assertEquals(listOf("a", "b", "c"), result.entriesFor(HERO).map { it.componentId.value })
+    }
+
+    // ── HideComponent ───────────────────────────────────────────────────────
+
+    @Test
+    fun hideComponent_withSlotId_removesFromThatSlotOnly() {
+        val state = LayoutState(
+            slots = mapOf(
+                HERO to listOf(entry("a")),
+                FOOTER to listOf(entry("a")),
+            )
+        )
+        val directive = AgentLayoutDirective.HideComponent(
+            componentId = ComponentId("a"),
+            slotId = HERO,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val result = LayoutReducer.apply(state, directive)
+
+        assertEquals(emptyList(), result.entriesFor(HERO))
+        assertEquals(listOf("a"), result.entriesFor(FOOTER).map { it.componentId.value })
+        assertEquals(1L, result.version)
+    }
+
+    @Test
+    fun hideComponent_withNullSlotId_removesFromAllSlots() {
+        val state = LayoutState(
+            slots = mapOf(
+                HERO to listOf(entry("a")),
+                FOOTER to listOf(entry("a"), entry("b")),
+            )
+        )
+        val directive = AgentLayoutDirective.HideComponent(
+            componentId = ComponentId("a"),
+            slotId = null,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val result = LayoutReducer.apply(state, directive)
+
+        assertEquals(emptyList(), result.entriesFor(HERO))
+        assertEquals(listOf("b"), result.entriesFor(FOOTER).map { it.componentId.value })
+    }
+
+    @Test
+    fun hideComponent_absentComponent_leavesSlotUnchanged() {
+        val state = stateWith(HERO, entry("a"))
+        val directive = AgentLayoutDirective.HideComponent(
+            componentId = ComponentId("missing"),
+            slotId = HERO,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val result = LayoutReducer.apply(state, directive)
+
+        assertEquals(listOf("a"), result.entriesFor(HERO).map { it.componentId.value })
+        assertEquals(1L, result.version)
+    }
+
+    // ── ReorderComponents ───────────────────────────────────────────────────
+
+    @Test
+    fun reorderComponents_explicitOrderThenRemainder() {
+        val state = stateWith(HERO, entry("a"), entry("b"), entry("c"))
+        val directive = AgentLayoutDirective.ReorderComponents(
+            slotId = HERO,
+            orderedComponentIds = listOf(ComponentId("c"), ComponentId("a")),
+            correlationId = DirectiveId("d1"),
+        )
+
+        val result = LayoutReducer.apply(state, directive)
+
+        assertEquals(listOf("c", "a", "b"), result.entriesFor(HERO).map { it.componentId.value })
+        assertEquals(1L, result.version)
+    }
+
+    @Test
+    fun reorderComponents_unknownIdsAreIgnored() {
+        val state = stateWith(HERO, entry("a"), entry("b"))
+        val directive = AgentLayoutDirective.ReorderComponents(
+            slotId = HERO,
+            orderedComponentIds = listOf(ComponentId("missing"), ComponentId("b")),
+            correlationId = DirectiveId("d1"),
+        )
+
+        val result = LayoutReducer.apply(state, directive)
+
+        assertEquals(listOf("b", "a"), result.entriesFor(HERO).map { it.componentId.value })
+    }
+
+    @Test
+    fun reorderComponents_missingSlot_isNoOp() {
+        val state = LayoutState.Empty
+        val directive = AgentLayoutDirective.ReorderComponents(
+            slotId = HERO,
+            orderedComponentIds = listOf(ComponentId("a")),
+            correlationId = DirectiveId("d1"),
+        )
+
+        val result = LayoutReducer.apply(state, directive)
+
+        assertEquals(state, result)
+    }
+
+    // ── SwapComponent ────────────────────────────────────────────────────────
+
+    @Test
+    fun swapComponent_replacesTargetWithNewEntry() {
+        val state = stateWith(HERO, entry("a"), entry("b"))
+        val directive = AgentLayoutDirective.SwapComponent(
+            slotId = HERO,
+            removeComponentId = ComponentId("a"),
+            insertComponentId = ComponentId("c"),
+            props = ComponentProps(mapOf("k" to "v")),
+            correlationId = DirectiveId("d1"),
+        )
+
+        val result = LayoutReducer.apply(state, directive, now = NOW)
+
+        val entries = result.entriesFor(HERO)
+        assertEquals(listOf("c", "b"), entries.map { it.componentId.value })
+        assertEquals("v", entries.first().props.get("k"))
+        assertEquals(NOW, entries.first().addedAt)
+        assertEquals(1L, result.version)
+    }
+
+    @Test
+    fun swapComponent_missingSlot_isNoOp() {
+        val state = LayoutState.Empty
+        val directive = AgentLayoutDirective.SwapComponent(
+            slotId = HERO,
+            removeComponentId = ComponentId("a"),
+            insertComponentId = ComponentId("b"),
+            correlationId = DirectiveId("d1"),
+        )
+
+        val result = LayoutReducer.apply(state, directive)
+
+        assertEquals(state, result)
+    }
+
+    // ── LockComponent ────────────────────────────────────────────────────────
+
+    @Test
+    fun lockComponent_appliesLockModeToTargetOnly() {
+        val state = stateWith(HERO, entry("a"), entry("b"))
+        val directive = AgentLayoutDirective.LockComponent(
+            componentId = ComponentId("a"),
+            slotId = HERO,
+            lockMode = LockMode.ReadOnly,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val result = LayoutReducer.apply(state, directive)
+
+        val entries = result.entriesFor(HERO)
+        assertEquals(LockMode.ReadOnly, entries.first { it.componentId.value == "a" }.lockMode)
+        assertEquals(null, entries.first { it.componentId.value == "b" }.lockMode)
+        assertEquals(1L, result.version)
+    }
+
+    @Test
+    fun lockComponent_missingSlot_isNoOp() {
+        val state = LayoutState.Empty
+        val directive = AgentLayoutDirective.LockComponent(
+            componentId = ComponentId("a"),
+            slotId = HERO,
+            lockMode = LockMode.Hidden,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val result = LayoutReducer.apply(state, directive)
+
+        assertEquals(state, result)
+    }
+
+    // ── positionFallsBackToEnd ──────────────────────────────────────────────
+
+    @Test
+    fun positionFallsBackToEnd_falseForNonShowDirective() {
+        val state = stateWith(HERO, entry("a"))
+        val directive = AgentLayoutDirective.HideComponent(
+            componentId = ComponentId("a"),
+            slotId = HERO,
+            correlationId = DirectiveId("d1"),
+        )
+
+        assertFalse(LayoutReducer.positionFallsBackToEnd(state, directive))
+    }
+
+    @Test
+    fun positionFallsBackToEnd_falseForStartEndIndexPositions() {
+        val state = stateWith(HERO, entry("a"))
+
+        assertFalse(LayoutReducer.positionFallsBackToEnd(state, show("b", HERO, Position.Start)))
+        assertFalse(LayoutReducer.positionFallsBackToEnd(state, show("b", HERO, Position.End)))
+        assertFalse(LayoutReducer.positionFallsBackToEnd(state, show("b", HERO, Position.Index(0))))
+    }
+
+    @Test
+    fun positionFallsBackToEnd_trueWhenReferenceMissing() {
+        val state = stateWith(HERO, entry("a"))
+
+        assertTrue(LayoutReducer.positionFallsBackToEnd(state, show("b", HERO, Position.Before(ComponentId("missing")))))
+        assertTrue(LayoutReducer.positionFallsBackToEnd(state, show("b", HERO, Position.After(ComponentId("missing")))))
+    }
+
+    @Test
+    fun positionFallsBackToEnd_falseWhenReferencePresent() {
+        val state = stateWith(HERO, entry("a"))
+
+        assertFalse(LayoutReducer.positionFallsBackToEnd(state, show("b", HERO, Position.Before(ComponentId("a")))))
+        assertFalse(LayoutReducer.positionFallsBackToEnd(state, show("b", HERO, Position.After(ComponentId("a")))))
+    }
+}
+
+private val NOW: Instant = Instant.fromEpochMilliseconds(0)
+private val HERO = SlotId("hero")
+private val FOOTER = SlotId("footer")
+
+private fun entry(id: String, addedAt: Instant = NOW): SlotEntry =
+    SlotEntry(componentId = ComponentId(id), props = ComponentProps.Empty, addedAt = addedAt)
+
+private fun stateWith(slotId: SlotId, vararg entries: SlotEntry): LayoutState =
+    LayoutState(slots = mapOf(slotId to entries.toList()))
+
+private fun show(componentId: String, slotId: SlotId, position: Position): AgentLayoutDirective.ShowComponent =
+    AgentLayoutDirective.ShowComponent(
+        componentId = ComponentId(componentId),
+        slotId = slotId,
+        position = position,
+        correlationId = DirectiveId("d-$componentId"),
+        issuedAt = NOW,
+    )

--- a/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/layout/SdkLayoutPolicyTest.kt
+++ b/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/layout/SdkLayoutPolicyTest.kt
@@ -1,0 +1,402 @@
+package io.github.koogcompose.layout
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class SdkLayoutPolicyTest {
+
+    // ── ShowComponent ────────────────────────────────────────────────────
+
+    @Test
+    fun show_validComponent_isAllowed() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+
+        val decision = policy.evaluate(show(BANNER), LayoutState.Empty, workflowContext())
+
+        assertEquals(PolicyDecision.Allow, decision)
+    }
+
+    @Test
+    fun show_unknownSlot_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+
+        val decision = policy.evaluate(show(BANNER, slotId = SlotId("missing")), LayoutState.Empty, workflowContext())
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.SchemaValidation, (decision as PolicyDecision.Deny).stage)
+    }
+
+    @Test
+    fun show_unknownComponent_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+
+        val decision = policy.evaluate(show(ComponentId("missing")), LayoutState.Empty, workflowContext())
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.SchemaValidation, (decision as PolicyDecision.Deny).stage)
+    }
+
+    @Test
+    fun show_tagMismatch_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+
+        val decision = policy.evaluate(show(WRONG_TAG), LayoutState.Empty, workflowContext())
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.SlotConstraintCheck, (decision as PolicyDecision.Deny).stage)
+    }
+
+    @Test
+    fun show_insufficientPermissions_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+
+        val decision = policy.evaluate(
+            show(ADMIN_PANEL),
+            LayoutState.Empty,
+            workflowContext(permissions = setOf(Permissions.Read)),
+        )
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.PolicyCheck, (decision as PolicyDecision.Deny).stage)
+    }
+
+    @Test
+    fun show_sufficientPermissions_isAllowed() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+
+        val decision = policy.evaluate(
+            show(ADMIN_PANEL),
+            LayoutState.Empty,
+            workflowContext(permissions = setOf(Permissions.Admin)),
+        )
+
+        assertEquals(PolicyDecision.Allow, decision)
+    }
+
+    // ── HideComponent ────────────────────────────────────────────────────
+
+    @Test
+    fun hide_unknownSlot_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val directive = AgentLayoutDirective.HideComponent(
+            componentId = BANNER,
+            slotId = SlotId("missing"),
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, LayoutState.Empty, workflowContext())
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.SchemaValidation, (decision as PolicyDecision.Deny).stage)
+    }
+
+    @Test
+    fun hide_unknownComponent_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val directive = AgentLayoutDirective.HideComponent(
+            componentId = ComponentId("missing"),
+            slotId = HERO,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, LayoutState.Empty, workflowContext())
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.SchemaValidation, (decision as PolicyDecision.Deny).stage)
+    }
+
+    @Test
+    fun hide_nullSlotId_knownComponent_isAllowed() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val directive = AgentLayoutDirective.HideComponent(
+            componentId = BANNER,
+            slotId = null,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, LayoutState.Empty, workflowContext())
+
+        assertEquals(PolicyDecision.Allow, decision)
+    }
+
+    // ── ReorderComponents ────────────────────────────────────────────────
+
+    @Test
+    fun reorder_unknownSlot_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val directive = AgentLayoutDirective.ReorderComponents(
+            slotId = SlotId("missing"),
+            orderedComponentIds = emptyList(),
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, LayoutState.Empty, workflowContext())
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.SchemaValidation, (decision as PolicyDecision.Deny).stage)
+    }
+
+    @Test
+    fun reorder_knownSlot_isAllowed() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val directive = AgentLayoutDirective.ReorderComponents(
+            slotId = HERO,
+            orderedComponentIds = listOf(BANNER),
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, LayoutState.Empty, workflowContext())
+
+        assertEquals(PolicyDecision.Allow, decision)
+    }
+
+    // ── SwapComponent ────────────────────────────────────────────────────
+
+    @Test
+    fun swap_validSwap_isAllowed() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val state = stateWith(HERO, BANNER)
+        val directive = AgentLayoutDirective.SwapComponent(
+            slotId = HERO,
+            removeComponentId = BANNER,
+            insertComponentId = ADMIN_PANEL,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, state, workflowContext(permissions = setOf(Permissions.Admin)))
+
+        assertEquals(PolicyDecision.Allow, decision)
+    }
+
+    @Test
+    fun swap_removeComponentNotInSlot_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val directive = AgentLayoutDirective.SwapComponent(
+            slotId = HERO,
+            removeComponentId = BANNER,
+            insertComponentId = ADMIN_PANEL,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, LayoutState.Empty, workflowContext(permissions = setOf(Permissions.Admin)))
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.Reduce, (decision as PolicyDecision.Deny).stage)
+    }
+
+    @Test
+    fun swap_insertComponentTagMismatch_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val state = stateWith(HERO, BANNER)
+        val directive = AgentLayoutDirective.SwapComponent(
+            slotId = HERO,
+            removeComponentId = BANNER,
+            insertComponentId = WRONG_TAG,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, state, workflowContext())
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.SlotConstraintCheck, (decision as PolicyDecision.Deny).stage)
+    }
+
+    @Test
+    fun swap_insertComponentInsufficientPermissions_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val state = stateWith(HERO, BANNER)
+        val directive = AgentLayoutDirective.SwapComponent(
+            slotId = HERO,
+            removeComponentId = BANNER,
+            insertComponentId = ADMIN_PANEL,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, state, workflowContext(permissions = setOf(Permissions.Read)))
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.PolicyCheck, (decision as PolicyDecision.Deny).stage)
+    }
+
+    // ── LockComponent ────────────────────────────────────────────────────
+
+    @Test
+    fun lock_componentNotInSlot_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val directive = AgentLayoutDirective.LockComponent(
+            componentId = BANNER,
+            slotId = HERO,
+            lockMode = LockMode.ReadOnly,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, LayoutState.Empty, workflowContext())
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.Reduce, (decision as PolicyDecision.Deny).stage)
+    }
+
+    @Test
+    fun lock_strengtheningExistingLock_isAllowed() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val state = stateWith(HERO, BANNER, lockMode = LockMode.ReadOnly)
+        val directive = AgentLayoutDirective.LockComponent(
+            componentId = BANNER,
+            slotId = HERO,
+            lockMode = LockMode.Hidden,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, state, workflowContext())
+
+        assertEquals(PolicyDecision.Allow, decision)
+    }
+
+    @Test
+    fun lock_weakeningExistingLock_isDenied() {
+        val policy = SdkLayoutPolicy(slotRegistry(), componentRegistry())
+        val state = stateWith(HERO, BANNER, lockMode = LockMode.Hidden)
+        val directive = AgentLayoutDirective.LockComponent(
+            componentId = BANNER,
+            slotId = HERO,
+            lockMode = LockMode.ReadOnly,
+            correlationId = DirectiveId("d1"),
+        )
+
+        val decision = policy.evaluate(directive, state, workflowContext())
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals(PipelineStage.PolicyCheck, (decision as PolicyDecision.Deny).stage)
+    }
+}
+
+class LayoutPolicyChainTest {
+
+    @Test
+    fun emptyChain_allowsEverything() {
+        val decision = LayoutPolicyChain.Empty.evaluate(show(BANNER), LayoutState.Empty, workflowContext())
+
+        assertEquals(PolicyDecision.Allow, decision)
+    }
+
+    @Test
+    fun firstDeny_shortCircuits() {
+        val denyPolicy = FakePolicy { PolicyDecision.Deny("nope") }
+        val neverCalled = FakePolicy { error("should not be evaluated") }
+        val chain = LayoutPolicyChain(listOf(denyPolicy, neverCalled))
+
+        val decision = chain.evaluate(show(BANNER), LayoutState.Empty, workflowContext())
+
+        assertTrue(decision is PolicyDecision.Deny)
+        assertEquals("nope", (decision as PolicyDecision.Deny).reason)
+    }
+
+    @Test
+    fun rewrite_isPassedToSubsequentPolicies() {
+        val rewritten = show(ADMIN_PANEL)
+        val rewritePolicy = FakePolicy { PolicyDecision.Rewrite(rewritten, "rewrote") }
+        var seenBySecondPolicy: AgentLayoutDirective? = null
+        val secondPolicy = FakePolicy { directive ->
+            seenBySecondPolicy = directive
+            PolicyDecision.Allow
+        }
+        val chain = LayoutPolicyChain(listOf(rewritePolicy, secondPolicy))
+
+        val decision = chain.evaluate(show(BANNER), LayoutState.Empty, workflowContext())
+
+        assertTrue(decision is PolicyDecision.Rewrite)
+        assertEquals(rewritten, (decision as PolicyDecision.Rewrite).replacement)
+        assertEquals(rewritten, seenBySecondPolicy)
+    }
+}
+
+class ComponentRegistryValidationTest {
+
+    @Test
+    fun validateAgainst_passesWhenFallbackComponentMatchesTags() {
+        val registry = ComponentRegistry(listOf(ComponentDefinition(BANNER, setOf(PROMO))))
+        val slots = SlotRegistry(
+            listOf(LayoutSlot(HERO, SlotCapacity.Single, setOf(PROMO), SlotDefault.FallbackComponent(BANNER)))
+        )
+
+        registry.validateAgainst(slots)
+    }
+
+    @Test
+    fun validateAgainst_throwsWhenFallbackComponentNotRegistered() {
+        val registry = ComponentRegistry(emptyList())
+        val slots = SlotRegistry(
+            listOf(LayoutSlot(HERO, SlotCapacity.Single, setOf(PROMO), SlotDefault.FallbackComponent(BANNER)))
+        )
+
+        assertFailsWith<IllegalStateException> { registry.validateAgainst(slots) }
+    }
+
+    @Test
+    fun validateAgainst_throwsWhenFallbackComponentTagDoesNotMatchSlot() {
+        val registry = ComponentRegistry(listOf(ComponentDefinition(BANNER, setOf(OTHER))))
+        val slots = SlotRegistry(
+            listOf(LayoutSlot(HERO, SlotCapacity.Single, setOf(PROMO), SlotDefault.FallbackComponent(BANNER)))
+        )
+
+        assertFailsWith<IllegalArgumentException> { registry.validateAgainst(slots) }
+    }
+}
+
+// ── Shared fixtures ─────────────────────────────────────────────────────────
+
+private val NOW: Instant = Instant.fromEpochMilliseconds(0)
+private val HERO = SlotId("hero")
+private val PROMO = Tag("promo")
+private val OTHER = Tag("other")
+
+private val BANNER = ComponentId("banner")
+private val ADMIN_PANEL = ComponentId("admin_panel")
+private val WRONG_TAG = ComponentId("wrong_tag")
+
+private fun slotRegistry(): SlotRegistry = SlotRegistry(
+    listOf(LayoutSlot(HERO, SlotCapacity.Multiple(3), setOf(PROMO)))
+)
+
+private fun componentRegistry(): ComponentRegistry = ComponentRegistry(
+    listOf(
+        ComponentDefinition(BANNER, setOf(PROMO)),
+        ComponentDefinition(ADMIN_PANEL, setOf(PROMO), setOf(Permissions.Admin)),
+        ComponentDefinition(WRONG_TAG, setOf(OTHER)),
+    )
+)
+
+private class TestUserRole(permissions: Set<Permission>) : UserRole(
+    id = "viewer",
+    displayName = "Viewer",
+    permissions = permissions,
+)
+
+private fun workflowContext(permissions: Set<Permission> = setOf(Permissions.Read)): WorkflowContext = WorkflowContext(
+    businessId = BusinessId("biz-1"),
+    userRole = TestUserRole(permissions),
+    activeWorkflow = WorkflowId("wf-1"),
+    deviceContext = DeviceContext(Platform.Android, FormFactor.Phone, NetworkClass.Online, "en-US"),
+)
+
+private fun show(
+    componentId: ComponentId,
+    slotId: SlotId = HERO,
+    position: Position = Position.End,
+): AgentLayoutDirective.ShowComponent = AgentLayoutDirective.ShowComponent(
+    componentId = componentId,
+    slotId = slotId,
+    position = position,
+    correlationId = DirectiveId("d1"),
+)
+
+private fun stateWith(slotId: SlotId, componentId: ComponentId, lockMode: LockMode? = null): LayoutState =
+    LayoutState(slots = mapOf(slotId to listOf(SlotEntry(componentId, ComponentProps.Empty, lockMode, addedAt = NOW))))
+
+private class FakePolicy(private val decide: (AgentLayoutDirective) -> PolicyDecision) : LayoutPolicy {
+    override fun evaluate(directive: AgentLayoutDirective, state: LayoutState, context: WorkflowContext): PolicyDecision =
+        decide(directive)
+}

--- a/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/layout/SdkLayoutPolicyTest.kt
+++ b/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/layout/SdkLayoutPolicyTest.kt
@@ -369,7 +369,7 @@ private fun componentRegistry(): ComponentRegistry = ComponentRegistry(
     )
 )
 
-private class TestUserRole(permissions: Set<Permission>) : UserRole(
+private class PolicyTestUserRole(permissions: Set<Permission>) : UserRole(
     id = "viewer",
     displayName = "Viewer",
     permissions = permissions,
@@ -377,7 +377,7 @@ private class TestUserRole(permissions: Set<Permission>) : UserRole(
 
 private fun workflowContext(permissions: Set<Permission> = setOf(Permissions.Read)): WorkflowContext = WorkflowContext(
     businessId = BusinessId("biz-1"),
-    userRole = TestUserRole(permissions),
+    userRole = PolicyTestUserRole(permissions),
     activeWorkflow = WorkflowId("wf-1"),
     deviceContext = DeviceContext(Platform.Android, FormFactor.Phone, NetworkClass.Online, "en-US"),
 )

--- a/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/provider/KoogProviderHelpersTest.kt
+++ b/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/provider/KoogProviderHelpersTest.kt
@@ -42,6 +42,82 @@ class KoogProviderHelpersTest {
     }
 
     @Test
+    fun generationDefaults_anthropic_usesConfiguredValues() {
+        val defaults = ProviderConfig.Anthropic(
+            apiKey = "key",
+            maxTokens = 2048,
+            temperature = 0.5,
+        ).generationDefaults()
+
+        assertEquals(0.5, defaults.temperature)
+        assertEquals(2048, defaults.maxTokens)
+    }
+
+    @Test
+    fun generationDefaults_openAI_usesConfiguredValues() {
+        val defaults = ProviderConfig.OpenAI(
+            apiKey = "key",
+            maxTokens = 1024,
+            temperature = 0.2,
+        ).generationDefaults()
+
+        assertEquals(0.2, defaults.temperature)
+        assertEquals(1024, defaults.maxTokens)
+    }
+
+    @Test
+    fun generationDefaults_ollama_usesConfiguredValues() {
+        val defaults = ProviderConfig.Ollama(
+            model = "llama3.2",
+            maxTokens = 512,
+            temperature = 0.9,
+        ).generationDefaults()
+
+        assertEquals(0.9, defaults.temperature)
+        assertEquals(512, defaults.maxTokens)
+    }
+
+    @Test
+    fun generationDefaults_liteRtLm_suppressesTemperatureButKeepsMaxTokens() {
+        val defaults = ProviderConfig.LiteRtLm(
+            maxTokens = 1024,
+            temperature = 0.7,
+        ).generationDefaults()
+
+        assertEquals(null, defaults.temperature)
+        assertEquals(1024, defaults.maxTokens)
+    }
+
+    @Test
+    fun generationDefaults_onDevice_isAlwaysNull() {
+        val defaults = ProviderConfig.OnDevice(modelPath = "/path").generationDefaults()
+
+        assertEquals(null, defaults.temperature)
+        assertEquals(null, defaults.maxTokens)
+    }
+
+    @Test
+    fun generationDefaults_router_delegatesToFirstProvider() {
+        val defaults = ProviderConfig.Router(
+            providers = listOf(
+                ProviderConfig.OpenAI(apiKey = "key", maxTokens = 256, temperature = 0.3),
+                ProviderConfig.Anthropic(apiKey = "key2", maxTokens = 4096, temperature = 0.9),
+            )
+        ).generationDefaults()
+
+        assertEquals(0.3, defaults.temperature)
+        assertEquals(256, defaults.maxTokens)
+    }
+
+    @Test
+    fun generationDefaults_emptyRouter_isAlwaysNull() {
+        val defaults = ProviderConfig.Router(providers = emptyList()).generationDefaults()
+
+        assertEquals(null, defaults.temperature)
+        assertEquals(null, defaults.maxTokens)
+    }
+
+    @Test
     fun secureToolDescriptor_supportsArraysEnumsAndObjects() {
         val descriptor = StructuredTool().toKoogToolDescriptor()
 

--- a/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/reliability/CircuitBreakerGuardTest.kt
+++ b/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/reliability/CircuitBreakerGuardTest.kt
@@ -1,0 +1,123 @@
+package io.github.koogcompose.reliability
+
+import io.github.koogcompose.observability.AgentEvent
+import io.github.koogcompose.observability.EventSink
+import io.github.koogcompose.tool.PermissionLevel
+import io.github.koogcompose.tool.SecureTool
+import io.github.koogcompose.tool.ToolResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+
+class CircuitBreakerGuardTest {
+
+    @Test
+    fun openingTransition_emitsCircuitBreakerOpened() = runTest {
+        val tool = FakeTool(result = ToolResult.Failure("service down"))
+        val sink = RecordingEventSink()
+        val breaker = CircuitBreaker(failureThreshold = 1, cooldownMs = 60_000) { 0L }
+        val guard = CircuitBreakerGuard(tool, breaker, sessionId = "s1", eventSink = sink)
+
+        guard.execute(EMPTY_ARGS)
+
+        assertTrue(breaker.isOpen)
+        assertEquals(1, sink.events.size)
+        val event = sink.events.single()
+        assertTrue(event is AgentEvent.CircuitBreakerOpened)
+        event as AgentEvent.CircuitBreakerOpened
+        assertEquals("s1", event.sessionId)
+        assertEquals("fake", event.toolName)
+        assertEquals(60_000, event.cooldownMs)
+    }
+
+    @Test
+    fun recoveryTransition_emitsCircuitBreakerClosed() = runTest {
+        var now = 0L
+        val tool = FakeTool(result = ToolResult.Failure("service down"))
+        val sink = RecordingEventSink()
+        val breaker = CircuitBreaker(failureThreshold = 1, cooldownMs = 1_000, successThreshold = 1) { now }
+        val guard = CircuitBreakerGuard(tool, breaker, sessionId = "s1", eventSink = sink)
+
+        guard.execute(EMPTY_ARGS) // → OPEN (emits Opened)
+        assertTrue(breaker.isOpen)
+
+        now = 1_000
+        tool.result = ToolResult.Success("recovered")
+        guard.execute(EMPTY_ARGS) // open-check → HALF_OPEN, success → CLOSED (emits Closed)
+
+        assertFalse(breaker.isOpen)
+        assertTrue(sink.events.any { it is AgentEvent.CircuitBreakerClosed })
+        val closed = sink.events.filterIsInstance<AgentEvent.CircuitBreakerClosed>().single()
+        assertEquals("s1", closed.sessionId)
+        assertEquals("fake", closed.toolName)
+    }
+
+    @Test
+    fun openCircuit_returnsFriendlyFailure_withoutCallingDelegate() = runTest {
+        val tool = FakeTool(result = ToolResult.Failure("service down"))
+        val sink = RecordingEventSink()
+        val breaker = CircuitBreaker(failureThreshold = 1, cooldownMs = 60_000) { 0L }
+        val guard = CircuitBreakerGuard(tool, breaker, eventSink = sink)
+
+        guard.execute(EMPTY_ARGS) // → OPEN
+        tool.callCount = 0
+
+        val result = guard.execute(EMPTY_ARGS)
+
+        assertTrue(result is ToolResult.Failure)
+        assertEquals(0, tool.callCount) // delegate not invoked while open
+        // No new transition event from the short-circuited call.
+        assertEquals(1, sink.events.size)
+    }
+
+    @Test
+    fun deniedResult_doesNotCountAsFailure_norEmitsEvent() = runTest {
+        val tool = FakeTool(result = ToolResult.Denied("policy"))
+        val sink = RecordingEventSink()
+        val breaker = CircuitBreaker(failureThreshold = 1) { 0L }
+        val guard = CircuitBreakerGuard(tool, breaker, eventSink = sink)
+
+        guard.execute(EMPTY_ARGS)
+
+        assertFalse(breaker.isOpen)
+        assertTrue(sink.events.isEmpty())
+    }
+
+    @Test
+    fun successWhileClosed_emitsNoEvent() = runTest {
+        val tool = FakeTool(result = ToolResult.Success("ok"))
+        val sink = RecordingEventSink()
+        val breaker = CircuitBreaker(failureThreshold = 3) { 0L }
+        val guard = CircuitBreakerGuard(tool, breaker, eventSink = sink)
+
+        guard.execute(EMPTY_ARGS)
+
+        assertTrue(sink.events.isEmpty())
+    }
+}
+
+private val EMPTY_ARGS = JsonObject(emptyMap())
+
+private class RecordingEventSink : EventSink {
+    val events = mutableListOf<AgentEvent>()
+    override suspend fun emit(event: AgentEvent) {
+        events.add(event)
+    }
+}
+
+private class FakeTool(
+    override val name: String = "fake",
+    var result: ToolResult,
+) : SecureTool {
+    override val description: String = "fake tool"
+    override val permissionLevel: PermissionLevel = PermissionLevel.SAFE
+    var callCount: Int = 0
+
+    override suspend fun execute(args: JsonObject): ToolResult {
+        callCount++
+        return result
+    }
+}

--- a/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/reliability/CircuitBreakerTest.kt
+++ b/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/reliability/CircuitBreakerTest.kt
@@ -1,0 +1,137 @@
+package io.github.koogcompose.reliability
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class CircuitBreakerTest {
+
+    @Test
+    fun closed_passesThroughSuccessfulCalls() = runTest {
+        val breaker = CircuitBreaker(failureThreshold = 3)
+
+        val result = breaker.call { "ok" }
+
+        assertEquals("ok", result)
+        assertFalse(breaker.isOpen)
+    }
+
+    @Test
+    fun failuresBelowThreshold_keepCircuitClosed() = runTest {
+        val breaker = CircuitBreaker(failureThreshold = 3)
+
+        repeat(2) {
+            assertFailsWith<IllegalStateException> { breaker.call { error("boom") } }
+        }
+
+        assertFalse(breaker.isOpen)
+        assertEquals(2, breaker.failuresSinceLastSuccess)
+    }
+
+    @Test
+    fun reachingFailureThreshold_opensCircuit() = runTest {
+        val breaker = CircuitBreaker(failureThreshold = 3)
+
+        repeat(3) {
+            assertFailsWith<IllegalStateException> { breaker.call { error("boom") } }
+        }
+
+        assertTrue(breaker.isOpen)
+    }
+
+    @Test
+    fun openCircuit_rejectsCallsWithCircuitOpenException() = runTest {
+        val breaker = CircuitBreaker(failureThreshold = 1, cooldownMs = 60_000) { 0L }
+
+        assertFailsWith<IllegalStateException> { breaker.call { error("boom") } }
+        assertTrue(breaker.isOpen)
+
+        // Block is never invoked while open.
+        var invoked = false
+        assertFailsWith<CircuitOpenException> {
+            breaker.call { invoked = true; "unreachable" }
+        }
+        assertFalse(invoked)
+    }
+
+    @Test
+    fun successResetsFailureCount() = runTest {
+        val breaker = CircuitBreaker(failureThreshold = 3)
+
+        assertFailsWith<IllegalStateException> { breaker.call { error("boom") } }
+        assertFailsWith<IllegalStateException> { breaker.call { error("boom") } }
+        breaker.call { "recovered" }
+
+        assertEquals(0, breaker.failuresSinceLastSuccess)
+        assertFalse(breaker.isOpen)
+    }
+
+    @Test
+    fun afterCooldown_circuitTransitionsToHalfOpen() = runTest {
+        var now = 0L
+        val breaker = CircuitBreaker(failureThreshold = 1, cooldownMs = 1_000) { now }
+
+        assertFailsWith<IllegalStateException> { breaker.call { error("boom") } }
+        assertTrue(breaker.isOpen)
+
+        now = 1_000
+        breaker.call { "trial" }
+        assertTrue(breaker.isHalfOpen)
+    }
+
+    @Test
+    fun halfOpen_successThresholdSuccesses_closesCircuit() = runTest {
+        var now = 0L
+        val breaker = CircuitBreaker(failureThreshold = 1, cooldownMs = 1_000, successThreshold = 2) { now }
+
+        assertFailsWith<IllegalStateException> { breaker.call { error("boom") } }
+        now = 1_000
+
+        breaker.call { "trial-1" }
+        assertTrue(breaker.isHalfOpen)
+        breaker.call { "trial-2" }
+        assertFalse(breaker.isHalfOpen)
+        assertFalse(breaker.isOpen)
+    }
+
+    @Test
+    fun halfOpen_failure_reopensCircuit() = runTest {
+        var now = 0L
+        val breaker = CircuitBreaker(failureThreshold = 1, cooldownMs = 1_000, successThreshold = 2) { now }
+
+        assertFailsWith<IllegalStateException> { breaker.call { error("boom") } }
+        now = 1_000
+        breaker.call { "trial" }
+        assertTrue(breaker.isHalfOpen)
+
+        assertFailsWith<IllegalStateException> { breaker.call { error("boom again") } }
+        assertTrue(breaker.isOpen)
+    }
+
+    @Test
+    fun recordSuccess_returnsTrueOnlyWhenItClosesTheCircuit() = runTest {
+        var now = 0L
+        val breaker = CircuitBreaker(failureThreshold = 1, cooldownMs = 1_000, successThreshold = 2) { now }
+
+        // Closed → success is not a transition.
+        assertFalse(breaker.recordSuccess())
+
+        assertTrue(breaker.recordFailure()) // CLOSED → OPEN
+        now = 1_000
+        // Enter HALF_OPEN via call(), then drive successes.
+        breaker.call { "trial-1" }
+        // One more success crosses successThreshold → CLOSED.
+        assertTrue(breaker.recordSuccess())
+    }
+
+    @Test
+    fun recordFailure_returnsTrueOnlyOnTransitionToOpen() = runTest {
+        val breaker = CircuitBreaker(failureThreshold = 2)
+
+        assertFalse(breaker.recordFailure()) // 1st failure, still closed
+        assertTrue(breaker.recordFailure())  // 2nd failure → OPEN
+    }
+}

--- a/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/security/GuardrailEnforcerTest.kt
+++ b/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/security/GuardrailEnforcerTest.kt
@@ -1,0 +1,200 @@
+package io.github.koogcompose.security
+
+import io.github.koogcompose.tool.PermissionLevel
+import io.github.koogcompose.tool.SecureTool
+import io.github.koogcompose.tool.ToolResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class GuardrailEnforcerTest {
+
+    // ── Rate limiting ────────────────────────────────────────────────────────
+
+    @Test
+    fun underRateLimit_isAllowed() = runTest {
+        val enforcer = GuardrailEnforcer(
+            Guardrails(toolRateLimits = mapOf("FetchTool" to Guardrails.RateLimit(max = 2, window = 1.hours))),
+            AuditLogger(),
+        )
+
+        assertNull(enforcer.validate("FetchTool", EMPTY_ARGS, userId = "u1"))
+        assertNull(enforcer.validate("FetchTool", EMPTY_ARGS, userId = "u1"))
+    }
+
+    @Test
+    fun exceedingRateLimit_isDenied() = runTest {
+        val enforcer = GuardrailEnforcer(
+            Guardrails(toolRateLimits = mapOf("FetchTool" to Guardrails.RateLimit(max = 1, window = 1.hours))),
+            AuditLogger(),
+        )
+
+        assertNull(enforcer.validate("FetchTool", EMPTY_ARGS, userId = "u1"))
+        val denied = enforcer.validate("FetchTool", EMPTY_ARGS, userId = "u1")
+
+        assertNotNull(denied)
+        assertTrue(denied.reason.contains("Rate limit"))
+    }
+
+    @Test
+    fun rateLimitDenial_isAudited() = runTest {
+        val audit = AuditLogger()
+        val enforcer = GuardrailEnforcer(
+            Guardrails(toolRateLimits = mapOf("FetchTool" to Guardrails.RateLimit(max = 1, window = 1.hours))),
+            audit,
+        )
+
+        enforcer.validate("FetchTool", EMPTY_ARGS, userId = "u1")
+        enforcer.validate("FetchTool", EMPTY_ARGS, userId = "u1")
+
+        assertEquals(1, audit.deniedCount)
+    }
+
+    @Test
+    fun toolWithoutRateLimit_isAlwaysAllowed() = runTest {
+        val enforcer = GuardrailEnforcer(Guardrails(), AuditLogger())
+
+        repeat(10) { assertNull(enforcer.validate("AnyTool", EMPTY_ARGS, userId = "u1")) }
+    }
+
+    // ── WorkManager tag allowlist ─────────────────────────────────────────────
+
+    @Test
+    fun workManagerTool_disallowedTag_isDenied() = runTest {
+        val enforcer = GuardrailEnforcer(
+            Guardrails(allowedWorkTags = setOf("sync")),
+            AuditLogger(),
+        )
+
+        val denied = enforcer.validate(
+            "WorkManagerScheduleTool",
+            buildJsonObject { put("tag", "evil") },
+            userId = "u1",
+        )
+
+        assertNotNull(denied)
+        assertTrue(denied.reason.contains("not in the allowlist"))
+    }
+
+    @Test
+    fun workManagerTool_allowedTag_isAllowed() = runTest {
+        val enforcer = GuardrailEnforcer(
+            Guardrails(allowedWorkTags = setOf("sync")),
+            AuditLogger(),
+        )
+
+        assertNull(
+            enforcer.validate("WorkManagerScheduleTool", buildJsonObject { put("tag", "sync") }, userId = "u1")
+        )
+    }
+
+    @Test
+    fun workManagerTool_emptyAllowlist_skipsTagCheck() = runTest {
+        val enforcer = GuardrailEnforcer(Guardrails(), AuditLogger())
+
+        assertNull(
+            enforcer.validate("WorkManagerScheduleTool", buildJsonObject { put("tag", "anything") }, userId = "u1")
+        )
+    }
+
+    @Test
+    fun maxScheduledJobsReached_isDenied() = runTest {
+        val enforcer = GuardrailEnforcer(
+            Guardrails(allowedWorkTags = setOf("sync"), maxScheduledJobs = 1),
+            AuditLogger(),
+        )
+
+        enforcer.notifyJobStarted()
+        val denied = enforcer.validate(
+            "WorkManagerScheduleTool",
+            buildJsonObject { put("tag", "sync") },
+            userId = "u1",
+        )
+
+        assertNotNull(denied)
+        assertTrue(denied.reason.contains("Maximum background jobs"))
+    }
+
+    @Test
+    fun notifyJobFinished_freesUpCapacity() = runTest {
+        val enforcer = GuardrailEnforcer(
+            Guardrails(allowedWorkTags = setOf("sync"), maxScheduledJobs = 1),
+            AuditLogger(),
+        )
+
+        enforcer.notifyJobStarted()
+        enforcer.notifyJobFinished()
+
+        assertNull(
+            enforcer.validate("WorkManagerScheduleTool", buildJsonObject { put("tag", "sync") }, userId = "u1")
+        )
+    }
+
+    // ── Intent action allowlist ───────────────────────────────────────────────
+
+    @Test
+    fun intentTool_disallowedAction_isDenied() = runTest {
+        val enforcer = GuardrailEnforcer(
+            Guardrails(allowedIntentActions = setOf("android.intent.action.VIEW")),
+            AuditLogger(),
+        )
+
+        val denied = enforcer.validate(
+            "SendIntentTool",
+            buildJsonObject { put("action", "android.intent.action.CALL") },
+            userId = "u1",
+        )
+
+        assertNotNull(denied)
+        assertTrue(denied.reason.contains("not in the allowlist"))
+    }
+
+    @Test
+    fun intentTool_allowedAction_isAllowed() = runTest {
+        val enforcer = GuardrailEnforcer(
+            Guardrails(allowedIntentActions = setOf("android.intent.action.VIEW")),
+            AuditLogger(),
+        )
+
+        assertNull(
+            enforcer.validate(
+                "SendIntentTool",
+                buildJsonObject { put("action", "android.intent.action.VIEW") },
+                userId = "u1",
+            )
+        )
+    }
+
+    // ── Confirmation hook ─────────────────────────────────────────────────────
+
+    @Test
+    fun requestConfirmation_defaultsToDenied() = runTest {
+        val enforcer = GuardrailEnforcer(Guardrails(), AuditLogger())
+
+        assertEquals(false, enforcer.requestConfirmation(FakeTool, EMPTY_ARGS))
+    }
+
+    @Test
+    fun requestConfirmation_usesInstalledHandler() = runTest {
+        val enforcer = GuardrailEnforcer(Guardrails(), AuditLogger())
+        enforcer.onConfirmationRequired = { _, _ -> true }
+
+        assertEquals(true, enforcer.requestConfirmation(FakeTool, EMPTY_ARGS))
+    }
+}
+
+private val EMPTY_ARGS = JsonObject(emptyMap())
+
+private object FakeTool : SecureTool {
+    override val name: String = "FakeTool"
+    override val description: String = "fake"
+    override val permissionLevel: PermissionLevel = PermissionLevel.SENSITIVE
+    override suspend fun execute(args: JsonObject): ToolResult = ToolResult.Success("ok")
+}

--- a/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/security/PermissionManagerTest.kt
+++ b/koog-compose-core/src/commonTest/kotlin/io/github/koogcompose/security/PermissionManagerTest.kt
@@ -1,0 +1,182 @@
+package io.github.koogcompose.security
+
+import io.github.koogcompose.tool.PermissionLevel
+import io.github.koogcompose.tool.SecureTool
+import io.github.koogcompose.tool.ToolResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PermissionManagerTest {
+
+    // ── check() ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun safeTool_isGrantedWithoutConfirmation() {
+        val pm = PermissionManager(AuditLogger())
+
+        val result = pm.check(TestTool("Safe", PermissionLevel.SAFE), EMPTY_ARGS)
+
+        assertEquals(PermissionCheckResult.Granted, result)
+    }
+
+    @Test
+    fun sensitiveTool_requiresConfirmationByDefault() {
+        val pm = PermissionManager(AuditLogger())
+
+        val result = pm.check(TestTool("Edit", PermissionLevel.SENSITIVE), EMPTY_ARGS)
+
+        assertTrue(result is PermissionCheckResult.RequiresConfirmation)
+        result as PermissionCheckResult.RequiresConfirmation
+        assertEquals(PermissionLevel.SENSITIVE, result.permissionLevel)
+        assertEquals("Edit", result.toolName)
+    }
+
+    @Test
+    fun sensitiveTool_grantedWhenConfirmationDisabled() {
+        val pm = PermissionManager(AuditLogger(), requireConfirmationForSensitive = false)
+
+        val result = pm.check(TestTool("Edit", PermissionLevel.SENSITIVE), EMPTY_ARGS)
+
+        assertEquals(PermissionCheckResult.Granted, result)
+    }
+
+    @Test
+    fun criticalTool_alwaysRequiresConfirmation() {
+        val pm = PermissionManager(AuditLogger(), requireConfirmationForSensitive = false)
+
+        val result = pm.check(TestTool("Delete", PermissionLevel.CRITICAL), EMPTY_ARGS)
+
+        assertTrue(result is PermissionCheckResult.RequiresConfirmation)
+        assertEquals(PermissionLevel.CRITICAL, (result as PermissionCheckResult.RequiresConfirmation).permissionLevel)
+    }
+
+    @Test
+    fun confirmationMessage_comesFromTool() {
+        val pm = PermissionManager(AuditLogger())
+
+        val result = pm.check(TestTool("Delete", PermissionLevel.CRITICAL, confirmation = "Really delete?"), EMPTY_ARGS)
+
+        assertEquals("Really delete?", (result as PermissionCheckResult.RequiresConfirmation).confirmationMessage)
+    }
+
+    // ── requestApproval() flow ──────────────────────────────────────────────────
+
+    @Test
+    fun requestApproval_confirmed_returnsTrueAndClearsPending() = runTest {
+        val pm = PermissionManager(AuditLogger())
+        val tool = TestTool("Delete", PermissionLevel.CRITICAL)
+
+        val deferred = async { pm.requestApproval(tool, EMPTY_ARGS) }
+        advanceUntilIdle()
+        assertTrue(pm.hasPendingConfirmation)
+
+        pm.onUserConfirmed()
+
+        assertTrue(deferred.await())
+        assertFalse(pm.hasPendingConfirmation)
+    }
+
+    @Test
+    fun requestApproval_denied_returnsFalse() = runTest {
+        val pm = PermissionManager(AuditLogger())
+        val tool = TestTool("Delete", PermissionLevel.CRITICAL)
+
+        val deferred = async { pm.requestApproval(tool, EMPTY_ARGS) }
+        advanceUntilIdle()
+
+        pm.onUserDenied()
+
+        assertFalse(deferred.await())
+        assertFalse(pm.hasPendingConfirmation)
+    }
+
+    @Test
+    fun confirmedApproval_isAudited() = runTest {
+        val audit = AuditLogger()
+        val pm = PermissionManager(audit)
+        val tool = TestTool("Delete", PermissionLevel.CRITICAL)
+
+        val deferred = async { pm.requestApproval(tool, EMPTY_ARGS) }
+        advanceUntilIdle()
+        pm.onUserConfirmed()
+        deferred.await()
+
+        assertEquals(1, audit.approvedCount)
+    }
+
+    @Test
+    fun deniedApproval_isAudited() = runTest {
+        val audit = AuditLogger()
+        val pm = PermissionManager(audit)
+        val tool = TestTool("Delete", PermissionLevel.CRITICAL)
+
+        val deferred = async { pm.requestApproval(tool, EMPTY_ARGS) }
+        advanceUntilIdle()
+        pm.onUserDenied()
+        deferred.await()
+
+        assertEquals(1, audit.deniedCount)
+    }
+
+    @Test
+    fun pendingConfirmation_exposesPendingTool() = runTest {
+        val pm = PermissionManager(AuditLogger())
+        val tool = TestTool("Delete", PermissionLevel.CRITICAL)
+
+        val deferred = async { pm.requestApproval(tool, EMPTY_ARGS) }
+        advanceUntilIdle()
+
+        val pending = pm.pendingConfirmation.value
+        assertEquals("Delete", pending?.tool?.name)
+        assertEquals(PermissionLevel.CRITICAL, pending?.permissionLevel)
+
+        pm.onUserConfirmed()
+        deferred.await()
+    }
+
+    // ── onUserConfirmed / onUserDenied without pending ──────────────────────────
+
+    @Test
+    fun onUserConfirmed_withoutPending_returnsDenied() = runTest {
+        val pm = PermissionManager(AuditLogger())
+
+        val result = pm.onUserConfirmed()
+
+        assertTrue(result is ToolResult.Denied)
+    }
+
+    @Test
+    fun clearPending_resetsState() = runTest {
+        val pm = PermissionManager(AuditLogger())
+        val tool = TestTool("Delete", PermissionLevel.CRITICAL)
+
+        val deferred = async { pm.requestApproval(tool, EMPTY_ARGS) }
+        advanceUntilIdle()
+        assertTrue(pm.hasPendingConfirmation)
+
+        pm.clearPending()
+
+        assertFalse(pm.hasPendingConfirmation)
+        deferred.cancel()
+    }
+}
+
+private val EMPTY_ARGS = JsonObject(emptyMap())
+
+private class TestTool(
+    override val name: String,
+    override val permissionLevel: PermissionLevel,
+    private val confirmation: String? = null,
+) : SecureTool {
+    override val description: String = "test tool"
+    override suspend fun execute(args: JsonObject): ToolResult = ToolResult.Success("ok")
+    override fun confirmationMessage(args: JsonObject): String = confirmation ?: description
+}


### PR DESCRIPTION
## Summary
This PR adds a comprehensive test suite covering the layout directive pipeline, security guardrails, permission management, circuit breaker reliability patterns, and related infrastructure. It also includes a CI workflow and updates documentation to reflect the generative UI layout engine.

## Key Changes

### Test Coverage
- **Layout Pipeline Tests** (`SdkLayoutPolicyTest.kt`, `LayoutReducerTest.kt`, `DefaultLayoutDirectiveProcessorTest.kt`):
  - Policy evaluation across all directive types (ShowComponent, HideComponent, ReorderComponents, SwapComponent, LockComponent)
  - Schema validation, slot constraint checking, and permission-based policy enforcement
  - State reduction and position handling (Start, End, Index, Before, After)
  - Slot capacity management (Single, Multiple, Unbounded) with eviction logic
  - Directive coalescing and position fallback detection

- **Security Tests** (`GuardrailEnforcerTest.kt`, `PermissionManagerTest.kt`):
  - Rate limiting enforcement per tool and user
  - WorkManager tag allowlist validation
  - Intent action allowlist validation
  - Permission levels (SAFE, SENSITIVE, CRITICAL) with confirmation flows
  - Audit logging of approvals and denials

- **Reliability Tests** (`CircuitBreakerTest.kt`, `CircuitBreakerGuardTest.kt`):
  - Circuit breaker state transitions (CLOSED → OPEN → HALF_OPEN → CLOSED)
  - Failure threshold and cooldown behavior
  - Success threshold for recovery validation
  - Event emission on state transitions
  - Graceful degradation when circuit is open

### Source Code Updates
- **`KoogaiProvider.kt`**: Refactored temperature/maxTokens defaults to use new `generationDefaults()` method on `ProviderConfig`, supporting Anthropic, OpenAI, Ollama, LiteRtLm, OnDevice, and Router variants
- **`CircuitBreaker.kt`**: Enhanced `recordSuccess()` to return boolean indicating HALF_OPEN → CLOSED transition for event emission
- **`AgentEvent.kt`**: Added `CircuitBreakerOpened` and `CircuitBreakerClosed` event types with session/tool/cooldown metadata
- **`LayoutReducer.kt`**: Added `wouldFallbackPosition()` helper to detect when Position.Before/After references are missing
- **`LayoutDirectiveProcessor.kt`**: Updated to use new policy/reducer APIs

### Documentation & CI
- **README.md**: Added "Generative UI layout" section documenting the directive pipeline, validation stages, outcome types, and position fallback behavior
- **.github/workflows/ci.yml**: New CI workflow running tests on ubuntu-latest and macos-latest for every push/PR, with per-target compile gates

### Test Helpers
- Extended `KoogProviderHelpersTest.kt` with generation defaults tests for all provider config variants
- Comprehensive test fixtures for layout state, directives, and policy chains

https://claude.ai/code/session_017RNj4ThRBTKnQMGaQTQgoS